### PR TITLE
Add Move and Scale modes

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -366,15 +366,15 @@ let loadBoardUI = ()=> {
 
   toolbar.on('move', () => {
     toolbar.setState({ transformMode: 'move' })
-    // storyboarderSketchPane.moveContents()
+    storyboarderSketchPane.moveContents()
   })
   toolbar.on('scale', () => {
     toolbar.setState({ transformMode: 'scale' })
-    // storyboarderSketchPane.scaleContents()
+    storyboarderSketchPane.scaleContents()
   })
   toolbar.on('cancelTransform', () => {
     toolbar.setState({ transformMode: null })
-    // storyboarderSketchPane.cancelTransform()
+    storyboarderSketchPane.cancelTransform()
   })
   // sketchPane.on('moveMode', enabled => {
   //   if (enabled) {

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -869,6 +869,7 @@ let goNextBoard = (direction, shouldPreserveSelections = false)=> {
 }
 
 let gotoBoard = (boardNumber, shouldPreserveSelections = false) => {
+  toolbar.emit('cancelTransform')
   return new Promise((resolve, reject) => {
     currentBoard = boardNumber
     currentBoard = Math.max(currentBoard, 0)

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -365,14 +365,24 @@ let loadBoardUI = ()=> {
 
 
   toolbar.on('move', () => {
+    if (storyboarderSketchPane.isPointerDown) return
+
     toolbar.setState({ transformMode: 'move' })
     storyboarderSketchPane.moveContents()
   })
   toolbar.on('scale', () => {
+    if (storyboarderSketchPane.isPointerDown) return
+
     toolbar.setState({ transformMode: 'scale' })
     storyboarderSketchPane.scaleContents()
   })
   toolbar.on('cancelTransform', () => {
+    // FIXME prevent this case from happening
+    if (storyboarderSketchPane.isPointerDown) {
+      console.warn('pointer is already down')
+      return
+    }
+
     toolbar.setState({ transformMode: null })
     storyboarderSketchPane.cancelTransform()
   })

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -339,13 +339,16 @@ let loadBoardUI = ()=> {
   })
 
   toolbar.on('brush', (kind, options) => {
+    toolbar.emit('cancelTransform')
     storyboarderSketchPane.setBrushTool(kind, options)
     sfx.playEffect('tool-' + kind)
   })
   toolbar.on('brush:size', size => {
+    toolbar.emit('cancelTransform')
     storyboarderSketchPane.setBrushSize(size)
   })
   toolbar.on('brush:color', color => {
+    toolbar.emit('cancelTransform')
     storyboarderSketchPane.setBrushColor(color)
   })
 
@@ -362,13 +365,16 @@ let loadBoardUI = ()=> {
 
 
   toolbar.on('move', () => {
-    // sketchPane.moveContents()
+    toolbar.setState({ transformMode: 'move' })
+    // storyboarderSketchPane.moveContents()
   })
   toolbar.on('scale', () => {
-    // sketchPane.scaleContents()
+    toolbar.setState({ transformMode: 'scale' })
+    // storyboarderSketchPane.scaleContents()
   })
   toolbar.on('cancelTransform', () => {
-    // sketchPane.cancelTransform()
+    toolbar.setState({ transformMode: null })
+    // storyboarderSketchPane.cancelTransform()
   })
   // sketchPane.on('moveMode', enabled => {
   //   if (enabled) {

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -2727,6 +2727,8 @@ const applyUndoStateForImage = (state) => {
 
       markImageFileDirty([layerData.index])
     }
+
+    toolbar.emit('cancelTransform')
   }).catch(e => console.error(e))
 }
 

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -513,7 +513,7 @@ class StoryboarderSketchPane extends EventEmitter {
   }
 
   moveContents () {
-    // TODO dispose of prior strategy?
+    if (this.strategy) this.strategy.dispose()
     this.strategy = new MovingStrategy(this)
   }
   scaleContents () {
@@ -582,6 +582,10 @@ class DrawingStrategy {
 
     context.restore()
   }
+  
+  dispose () {
+    //
+  }
 }
 
 class MovingStrategy {
@@ -603,6 +607,9 @@ class MovingStrategy {
         offset: [0, 0]
       }
     }
+
+    this.container.brushPointerContainer.innerHTML = ''
+    document.querySelector('#storyboarder-sketch-pane .container').style.cursor = 'move'
   }
 
   canvasPointerDown (e) {
@@ -687,6 +694,11 @@ class MovingStrategy {
     context.drawImage(this.storedLayers[index].canvas, this.storedLayers[index].offset[0], this.storedLayers[index].offset[1])
 
     context.restore()
+  }
+
+  dispose () {
+    this.container.updatePointer()
+    document.querySelector('#storyboarder-sketch-pane .container').style.cursor = 'none'
   }
 }
 

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -589,6 +589,20 @@ class MovingStrategy {
     this.container = container
     this.startAt = null
     this.pos = null
+
+    this.storedLayers = {}
+    for (let index of [0, 1, 3]) {// HACK hardcoded
+      let context = this.container.sketchPane.getLayerContext(index)
+      let storedCanvas = document.createElement('canvas')
+      let storedContext = storedCanvas.getContext('2d')
+      storedCanvas.width = context.canvas.width
+      storedCanvas.height = context.canvas.height
+      storedContext.drawImage(context.canvas, 0, 0)
+      this.storedLayers[index] = {
+        canvas: storedCanvas,
+        offset: [0, 0]
+      }
+    }
   }
 
   canvasPointerDown (e) {
@@ -663,17 +677,14 @@ class MovingStrategy {
     let w = this.container.sketchPane.size.width
     let h = this.container.sketchPane.size.height
 
-    let storedCanvas = document.createElement('canvas')
-    let storedContext = storedCanvas.getContext('2d')
-    storedCanvas.width = context.canvas.width
-    storedCanvas.height = context.canvas.height
-    storedContext.drawImage(context.canvas, 0, 0)
+    this.storedLayers[index].offset[0] += this.pos[0]
+    this.storedLayers[index].offset[1] += this.pos[1]
 
     context.save()
     context.globalAlpha = 1
 
     context.clearRect(0, 0, w, h)
-    context.drawImage(storedCanvas, this.pos[0], this.pos[1])
+    context.drawImage(this.storedLayers[index].canvas, this.storedLayers[index].offset[0], this.storedLayers[index].offset[1])
 
     context.restore()
   }

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -144,10 +144,25 @@ class StoryboarderSketchPane extends EventEmitter {
   }
 
   onKeyDown (e) {
-    this.setQuickEraseIfRequested()
+    if (keytracker('<alt>') && keytracker('<meta>')) {
+      this.toolbar.emit('scale')
+    } else if (keytracker('<meta>')) {
+      this.toolbar.emit('move')
+    } else {
+      this.setQuickEraseIfRequested()
+    }
   }
 
   onKeyUp (e) {
+    if (
+      !(keytracker('<alt>') && keytracker('<meta>')) &&
+      !keytracker('<meta>')
+    ) {
+      if (this.toolbar.state.transformMode) {
+        this.toolbar.emit('cancelTransform')
+      }
+    }
+    
     if (!this.getIsDrawingOrStabilizing()) {
       this.unsetQuickErase()
     }

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -628,7 +628,7 @@ class MovingStrategy {
       }
     }
 
-    this.container.brushPointerContainer.innerHTML = ''
+    this.container.brushPointerContainer.style.visibility = 'hidden'
     document.querySelector('#storyboarder-sketch-pane .container').style.cursor = 'move'
   }
 
@@ -731,6 +731,7 @@ class MovingStrategy {
     // force stop
     this.container.stopMultiLayerOperation()
 
+    this.container.brushPointerContainer.style.visibility = 'visible'
     this.container.updatePointer()
     document.querySelector('#storyboarder-sketch-pane .container').style.cursor = 'none'
 

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -748,7 +748,7 @@ class ScalingStrategy {
     this.scale = 1
 
     this.container.brushPointerContainer.style.visibility = 'hidden'
-    document.querySelector('#storyboarder-sketch-pane .container').style.cursor = 'move'
+    document.querySelector('#storyboarder-sketch-pane .container').style.cursor = 'ew-resize'
   }
 
   canvasPointerDown (e) {

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -514,10 +514,15 @@ class StoryboarderSketchPane extends EventEmitter {
     this.strategy = new MovingStrategy(this)
   }
   scaleContents () {
+    if (this.strategy) this.strategy.dispose()
     console.warn('Scale Contents Not Implemented')
   }
   cancelTransform () {
+    if (this.strategy) this.strategy.dispose()
     this.strategy = new DrawingStrategy(this)
+    if (this.toolbar) {
+      this.setBrushTool(this.toolbar.getBrushOptions().kind, this.toolbar.getBrushOptions())
+    }
   }  
 }
 
@@ -723,6 +728,9 @@ class MovingStrategy {
   }
 
   dispose () {
+    // force stop
+    this.container.stopMultiLayerOperation()
+
     this.container.updatePointer()
     document.querySelector('#storyboarder-sketch-pane .container').style.cursor = 'none'
 

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -252,8 +252,6 @@ class StoryboarderSketchPane extends EventEmitter {
     // draw composite from layers
     for (let index of this.visibleLayersIndices) {
       let canvas = this.sketchPane.getLayerCanvas(index)
-      let context = this.sketchPane.getLayerContext(index)
-
       compositeContext.drawImage(canvas, 0, 0)
     }
 

--- a/src/main-window.html
+++ b/src/main-window.html
@@ -129,14 +129,14 @@
             </div>
             <div id="toolbar-move" class="button" data-tooltip
               data-tooltip-title="Move Mode"
-              data-tooltip-description="(Not Implemented Yet)"
+              data-tooltip-description="Drag the image to move."
               data-tooltip-keys=""
               data-tooltip-position="bottom center">
               <svg class="icon"><use xlink:href="./img/symbol-defs.svg#icon-move"></use></svg>
             </div>
             <div id="toolbar-scale" class="button" data-tooltip
               data-tooltip-title="Scale Mode"
-              data-tooltip-description="(Not Implemented Yet)"
+              data-tooltip-description="Drag the image to scale."
               data-tooltip-keys=""
               data-tooltip-position="bottom center">
               <svg class="icon"><use xlink:href="./img/symbol-defs.svg#icon-scale"></use></svg>


### PR DESCRIPTION
Added move/scale modes back into the app.

Related:
- https://github.com/wonderunit/storyboarder/issues/161
- https://github.com/wonderunit/storyboarder/issues/243
- https://github.com/wonderunit/storyboarder/issues/244

Could use a refactoring pass. Very messy. Lots of code duplication in the strategies. Calls to `emit` that probably should be method calls.

Known Issues:
- https://github.com/wonderunit/storyboarder/issues/245
- https://github.com/wonderunit/storyboarder/issues/246
- https://github.com/wonderunit/storyboarder/issues/247