### PR TITLE
Onion Skin

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -600,3 +600,7 @@ ipcMain.on('textInputMode', (event, arg)=> {
 ipcMain.on('preferences', (event, arg) => {
   preferencesUI.show()
 })
+
+ipcMain.on('toggleOnionSkin', () => {
+  mainWindow.webContents.send('toggleOnionSkin')
+})

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -333,6 +333,13 @@ const template = [
         }
       },
       {
+        label: 'Toggle Onion Skin',
+        accelerator: 'o',
+        click ( item, focusedWindow, event) {
+          ipcRenderer.send('toggleOnionSkin')
+        }
+      },
+      {
         label: 'Toggle Captions',
         accelerator: 'c',
         click ( item, focusedWindow, event) {

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -2871,3 +2871,8 @@ ipcRenderer.on('textInputMode', (event, args)=>{
 ipcRenderer.on('importImage', (event, args)=> {
   importImage(args)
 })
+
+ipcRenderer.on('toggleOnionSkin', () => {
+  toolbar.setState({ 'onion': !toolbar.state.onion })
+  toolbar.emit('onion', toolbar.state.onion)
+})

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -731,7 +731,12 @@ let saveImageFile = () => {
 
 const updateThumbnail = imageFilePath => {
   let width = Math.floor(60 * boardData.aspectRatio), height = 60
+
+  storyboarderSketchPane.sketchPane.setLayerVisible(false, 2) // HACK hardcoded
+  storyboarderSketchPane.sketchPane.setLayerVisible(false, 4) // HACK hardcoded
   let canvas = storyboarderSketchPane.sketchPane.createFlattenThumbnail(width * 2, height * 2)
+  storyboarderSketchPane.sketchPane.setLayerVisible(true, 2) // HACK hardcoded
+  storyboarderSketchPane.sketchPane.setLayerVisible(true, 4) // HACK hardcoded
 
   let imageData = canvas
     .toDataURL('image/png')

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -18,6 +18,7 @@ const Transport = require('./transport.js')
 const notifications = require('./notifications.js')
 const NotificationData = require('../../data/messages.json')
 const Guides = require('./guides.js')
+const OnionSkin = require('./onion-skin.js')
 const Sonifier = require('./sonifier/index.js')
 const sfx = require('../wonderunit-sound.js')
 const keytracker = require('../utils/keytracker.js')
@@ -78,6 +79,7 @@ let contextMenu
 let colorPicker
 let transport
 let guides
+let onionSkin
 
 let storyboarderSketchPane
 
@@ -420,8 +422,8 @@ let loadBoardUI = ()=> {
   toolbar.on('diagonals', value => {
     guides.setState({ diagonals: value })
   })
-  toolbar.on('onion', () => {
-    alert('Onion Skin. This feature is not ready yet :(')
+  toolbar.on('onion', value => {
+    onionSkin.setEnabled(value)
   })
   toolbar.on('captions', () => {
     // HACK!!!
@@ -505,7 +507,7 @@ let loadBoardUI = ()=> {
   })
 
   guides = new Guides(storyboarderSketchPane.getLayerCanvasByName('guides'))
-
+  onionSkin = new OnionSkin(storyboarderSketchPane, boardPath)
 
   sfx.init()
 
@@ -1099,7 +1101,7 @@ let updateSketchPaneBoard = () => {
     let board = boardData.boards[currentBoard]
     
 
-    // always load the main board
+    // always load the main layer
     let layersData = [
       [1, board.url] // HACK hardcoded index
     ]
@@ -1171,7 +1173,12 @@ let updateSketchPaneBoard = () => {
           storyboarderSketchPane.sketchPane.clearLayer(index)
         }
       }
-      resolve()
+
+      onionSkin.load(
+        boardData.boards[currentBoard],
+        boardData.boards[currentBoard - 1],
+        boardData.boards[currentBoard + 1]
+      ).then(() => resolve()).catch(err => console.warn(err))
     }).catch(err => console.warn(err))
   })
 }

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -424,6 +424,15 @@ let loadBoardUI = ()=> {
   })
   toolbar.on('onion', value => {
     onionSkin.setEnabled(value)
+    if (onionSkin.getEnabled()) {
+      if (!onionSkin.isLoaded) {
+        onionSkin.load(
+          boardData.boards[currentBoard],
+          boardData.boards[currentBoard - 1],
+          boardData.boards[currentBoard + 1]
+        ).catch(err => console.warn(err))
+      }
+    }
   })
   toolbar.on('captions', () => {
     // HACK!!!
@@ -1174,11 +1183,14 @@ let updateSketchPaneBoard = () => {
         }
       }
 
-      onionSkin.load(
-        boardData.boards[currentBoard],
-        boardData.boards[currentBoard - 1],
-        boardData.boards[currentBoard + 1]
-      ).then(() => resolve()).catch(err => console.warn(err))
+      onionSkin.reset()
+      if (onionSkin.getEnabled()) {
+        onionSkin.load(
+          boardData.boards[currentBoard],
+          boardData.boards[currentBoard - 1],
+          boardData.boards[currentBoard + 1]
+        ).then(() => resolve()).catch(err => console.warn(err))
+      }
     }).catch(err => console.warn(err))
   })
 }

--- a/src/js/window/onion-skin.js
+++ b/src/js/window/onion-skin.js
@@ -72,43 +72,40 @@ class OnionSkin {
               if (fs.existsSync(imageFilePath)) {
                 let image = new Image()
                 image.onload = () => {
-                  // draw
-                  resolve([index, image])
+                  // resolve
+                  resolve([filename, image])
                 }
                 image.onerror = err => {
                   // clear
                   console.warn(err)
-                  resolve([index, null])
+                  resolve([filename, null])
                 }
                 image.src = imageFilePath + '?' + Math.random()
               } else {
                 // clear
-                resolve([index, null])
+                resolve([filename, null])
               }
             } catch (err) {
               // clear
-              resolve([index, null])
+              resolve([filename, null])
             }
           }))
         }
       }
 
       Promise.all(loaders).then(result => {
+        // key map for easier lookup
+        let imagesByFilename = {}
+        for (let [filename, image] of result) {
+          if (image) imagesByFilename[filename] = image
+        }
+
         context.save()
         context.globalAlpha = 0.25
         context.clearRect(0, 0, size.width, size.height)
         for (let [index, filename] of layersData) {
-
-          // key map for easier looku
-          let imagesToDrawByLayerIndex = []
-          for (let [index, image] of result) {
-            if (image) {
-              imagesToDrawByLayerIndex[index] = image
-            }
-          }
-
           // do we have an image for this particular layer index?
-          let image = imagesToDrawByLayerIndex[index]
+          let image = imagesByFilename[filename]
           if (image) {
             console.log('OnionSkin :: rendering layer index:', index, filename)
             context.drawImage(image, 0, 0)

--- a/src/js/window/onion-skin.js
+++ b/src/js/window/onion-skin.js
@@ -5,6 +5,7 @@ class OnionSkin {
   constructor (storyboarderSketchPane, boardPath) {
     this.storyboarderSketchPane = storyboarderSketchPane
     this.enabled = false
+    this.isLoaded = false
     this.boardPath = boardPath
 
     this.setEnabled(false)
@@ -16,7 +17,17 @@ class OnionSkin {
     console.log('OnionSkin#setEnabled', this.enabled)
   }
   
+  getEnabled () {
+    return this.enabled
+  }
+
+  reset () {
+    this.isLoaded = false
+  }
+
   load (currBoard, prevBoard, nextBoard) {
+    console.log('OnionSkin#load')
+    this.isLoaded = false
     return new Promise((resolve, reject) => {
       let context = this.storyboarderSketchPane.sketchPane.getLayerContext(2) // HACK hardcoded
       let size = this.storyboarderSketchPane.sketchPane.getCanvasSize()
@@ -107,6 +118,7 @@ class OnionSkin {
         }
         context.restore()
 
+        this.isLoaded = true
         resolve()
       })
     })

--- a/src/js/window/onion-skin.js
+++ b/src/js/window/onion-skin.js
@@ -1,0 +1,116 @@
+const fs = require('fs')
+const path = require('path')
+
+class OnionSkin {
+  constructor (storyboarderSketchPane, boardPath) {
+    this.storyboarderSketchPane = storyboarderSketchPane
+    this.enabled = false
+    this.boardPath = boardPath
+
+    this.setEnabled(false)
+  }
+
+  setEnabled (value) {
+    this.enabled = value
+    this.storyboarderSketchPane.sketchPane.setLayerOpacity(this.enabled ? 1 : 0, 2) // HACK hardcoded
+    console.log('OnionSkin#setEnabled', this.enabled)
+  }
+  
+  load (currBoard, prevBoard, nextBoard) {
+    return new Promise((resolve, reject) => {
+      let context = this.storyboarderSketchPane.sketchPane.getLayerContext(2) // HACK hardcoded
+      let size = this.storyboarderSketchPane.sketchPane.getCanvasSize()
+
+      // TODO if not enabled, clear the onion layer
+      // TODO   (this works, but when re-enabled on a new board, needs to know enough to reload images it doesn't have...)
+      // if (!this.enabled) {
+      //   context.clearRect(0, 0, size.width, size.height)
+      //   resolve()
+      //   return
+      // }
+
+      console.log('OnionSkin :: load')
+
+      let layersData = []
+      let loaders = []
+
+      for (let board of [prevBoard, nextBoard]) {
+        if (!board) continue
+
+        console.log('OnionSkin :: load', board.shot, board.url)
+
+        if (board.layers) {
+          if (board.layers.reference && board.layers.reference.url) {
+            layersData.push([0, board.layers.reference.url]) // HACK hardcoded index
+          }
+        }
+
+        // always load the main layer
+        layersData.push([1, board.url]) // HACK hardcoded index
+
+        if (board.layers) {
+          if (board.layers.notes && board.layers.notes.url) {
+            layersData.push([3, board.layers.notes.url]) // HACK hardcoded index
+          }
+        }
+
+        for (let [index, filename] of layersData) {
+          loaders.push(new Promise((resolve, reject) => {
+            let imageFilePath = path.join(this.boardPath, 'images', filename)
+            try {
+              if (fs.existsSync(imageFilePath)) {
+                let image = new Image()
+                image.onload = () => {
+                  // draw
+                  resolve([index, image])
+                }
+                image.onerror = err => {
+                  // clear
+                  console.warn(err)
+                  resolve([index, null])
+                }
+                image.src = imageFilePath + '?' + Math.random()
+              } else {
+                // clear
+                resolve([index, null])
+              }
+            } catch (err) {
+              // clear
+              resolve([index, null])
+            }
+          }))
+        }
+      }
+
+      Promise.all(loaders).then(result => {
+        context.save()
+        context.globalAlpha = 0.25
+        context.clearRect(0, 0, size.width, size.height)
+        for (let [index, filename] of layersData) {
+
+          // key map for easier looku
+          let imagesToDrawByLayerIndex = []
+          for (let [index, image] of result) {
+            if (image) {
+              imagesToDrawByLayerIndex[index] = image
+            }
+          }
+
+          // do we have an image for this particular layer index?
+          let image = imagesToDrawByLayerIndex[index]
+          if (image) {
+            console.log('OnionSkin :: rendering layer index:', index, filename)
+            context.drawImage(image, 0, 0)
+          } else {
+            console.log('OnionSkin :: missing image for layer index:', index, filename)
+          }
+        }
+        context.restore()
+
+        resolve()
+      })
+    })
+  }
+}
+
+module.exports = OnionSkin

--- a/src/js/window/onion-skin.js
+++ b/src/js/window/onion-skin.js
@@ -14,7 +14,6 @@ class OnionSkin {
   setEnabled (value) {
     this.enabled = value
     this.storyboarderSketchPane.sketchPane.setLayerOpacity(this.enabled ? 1 : 0, 2) // HACK hardcoded
-    console.log('OnionSkin#setEnabled', this.enabled)
   }
   
   getEnabled () {
@@ -26,21 +25,10 @@ class OnionSkin {
   }
 
   load (currBoard, prevBoard, nextBoard) {
-    console.log('OnionSkin#load')
     this.isLoaded = false
     return new Promise((resolve, reject) => {
       let context = this.storyboarderSketchPane.sketchPane.getLayerContext(2) // HACK hardcoded
       let size = this.storyboarderSketchPane.sketchPane.getCanvasSize()
-
-      // TODO if not enabled, clear the onion layer
-      // TODO   (this works, but when re-enabled on a new board, needs to know enough to reload images it doesn't have...)
-      // if (!this.enabled) {
-      //   context.clearRect(0, 0, size.width, size.height)
-      //   resolve()
-      //   return
-      // }
-
-      console.log('OnionSkin :: load')
 
       let layersData = []
       let loaders = []
@@ -48,8 +36,6 @@ class OnionSkin {
       for (let board of [prevBoard, nextBoard]) {
         if (!board) continue
 
-        console.log('OnionSkin :: load', board.shot, board.url)
-        
         let color = board == prevBoard ? '#00f' : '#f00'
 
         if (board.layers) {
@@ -110,7 +96,7 @@ class OnionSkin {
           // do we have an image for this particular layer index?
           let image = imagesByFilename[filename]
           if (image) {
-            console.log('OnionSkin :: rendering layer index:', index, filename, color)
+            // console.log('OnionSkin :: rendering layer index:', index, filename, color)
             tmpCtx.save()
             tmpCtx.fillStyle = color
             tmpCtx.fillRect(0, 0, size.width, size.height)
@@ -128,7 +114,7 @@ class OnionSkin {
             context.drawImage(tmpCtx.canvas, 0, 0)
             context.restore()
           } else {
-            console.log('OnionSkin :: missing image for layer index:', index, filename, color)
+            // console.log('OnionSkin :: missing image for layer index:', index, filename, color)
           }
         }
 

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -510,6 +510,18 @@ class StoryboarderSketchPane extends EventEmitter {
     }
   }
 
+  createContext () {
+    let size = [
+      this.sketchPane.getCanvasWidth(),
+      this.sketchPane.getCanvasHeight()
+    ]
+    let canvas = document.createElement('canvas')
+    let context = canvas.getContext('2d')
+    canvas.width = size[0]
+    canvas.height = size[1]
+    return context
+  }
+
   // FIXME DEPRECATED remove references in main-window if possible, use indices instead
   getLayerCanvasByName (name) {
     // HACK hardcoded
@@ -626,20 +638,15 @@ class MovingStrategy {
     this.pos = null
     this.offset = [0, 0]
 
-    let size = this.container.sketchPane.getCanvasSize()
-    this.storedComposite = document.createElement('canvas')
-    let storedContext = this.storedComposite.getContext('2d')
-    this.storedComposite.width = size.width
-    this.storedComposite.height = size.height
+    let storedContext = this.container.createContext()
+    this.storedComposite = storedContext.canvas
     this.container.drawComposite(this.container.visibleLayersIndices, storedContext)
 
     this.storedLayers = {}
     for (let index of [0, 1, 3]) {// HACK hardcoded
       let context = this.container.sketchPane.getLayerContext(index)
-      let storedCanvas = document.createElement('canvas')
-      let storedContext = storedCanvas.getContext('2d')
-      storedCanvas.width = context.canvas.width
-      storedCanvas.height = context.canvas.height
+      let storedContext = this.container.createContext()
+      let storedCanvas = storedContext.canvas
       storedContext.drawImage(context.canvas, 0, 0)
       this.storedLayers[index] = {
         canvas: storedCanvas,
@@ -860,10 +867,8 @@ class ScalingStrategy {
     let h = this.container.sketchPane.size.height
 
     // store a copy
-    let storedCanvas = document.createElement('canvas')
-    let storedContext = storedCanvas.getContext('2d')
-    storedCanvas.width = context.canvas.width
-    storedCanvas.height = context.canvas.height
+    
+    let storedContext = this.container.createContext()
     storedContext.drawImage(context.canvas, 0, 0)
 
     context.save()

--- a/src/js/window/toolbar.js
+++ b/src/js/window/toolbar.js
@@ -100,7 +100,9 @@ const initialState = {
   grid: false,
   center: false,
   thirds: false,
-  diagonals: false
+  diagonals: false,
+  
+  onion: false
 }
 
 class Toolbar extends EventEmitter {
@@ -338,7 +340,8 @@ class Toolbar extends EventEmitter {
         this.emit('diagonals', this.state.diagonals)
         break
       case 'onion':
-        this.emit('onion')
+        this.setState({ onion: !this.state.onion })
+        this.emit('onion', this.state.onion)
         break
       case 'captions':
         this.toggleCaptions()
@@ -442,6 +445,9 @@ class Toolbar extends EventEmitter {
     centerEl.classList.toggle('active', this.state.center)
     thirdsEl.classList.toggle('active', this.state.thirds)
     diagonalsEl.classList.toggle('active', this.state.diagonals)
+
+    let onionEl = this.el.querySelector('#toolbar-onion')
+    onionEl.classList.toggle('active', this.state.onion)
 
     if (this.state.brushes[this.state.brush].color) {
       this.el.querySelector('#toolbar-current-color .icon').style.backgroundColor = this.state.brushes[this.state.brush].color.toCSS()

--- a/src/main-window.html
+++ b/src/main-window.html
@@ -190,7 +190,7 @@
             <div id="toolbar-onion" class="button" data-tooltip
               data-tooltip-title="Onion Skin"
               data-tooltip-description="Toggle display of last and next frame so you can tween shots for transitions and animations."
-              data-tooltip-keys=""
+              data-tooltip-keys="o"
               data-tooltip-position="bottom center">
               <svg class="icon"><use xlink:href="./img/symbol-defs.svg#icon-onion"></use></svg>
             </div>


### PR DESCRIPTION
See https://github.com/wonderunit/storyboarder/issues/31

**TASKS**

- [x] When Onion Skin is disabled, prev/next layer files shouldn't be loaded
- [x] When Onion Skin is re-enabled, should be smart enough to load prev/next layers from disk if needed
- [x] Shouldn't composite onion skin in the thumbnail
- [x] remove console.logs
- [x] sometimes main layer doesn't onion skin properly from prev frame?
- [x] add to main menu, accelerator is o, add note re key to tooltip