### PR TITLE
Importing Images

### DIFF
--- a/src/js/files/FileReader.js
+++ b/src/js/files/FileReader.js
@@ -18,9 +18,6 @@ let getBase64ImageDataFromFilePath = (filepath) => {
       return getBase64TypeFromFilePath('png', filepath)
     case "jpg":
       return getBase64TypeFromFilePath('jpg', filepath)
-    case "tif":
-    case "tiff":
-      return getBase64TypeFromFilePath('tiff', filepath)
   }
 }
 

--- a/src/js/files/FileReader.js
+++ b/src/js/files/FileReader.js
@@ -1,0 +1,37 @@
+const path = require('path')
+const fs = require('fs')
+
+/**
+ * Retrieve a base 64 representation of an image file
+ *  
+ * @param {string} filepath 
+ * @returns {string}
+ */
+let getBase64ImageDataFromFilePath = (filepath) => {
+  let arr = filepath.split(path.sep)
+  let filename = arr[arr.length-1]
+  let filenameParts =filename.toLowerCase().split('.')
+  let type = filenameParts[filenameParts.length-1]
+
+  switch(type) {
+    case "png":
+      return getBase64TypeFromFilePath('png', filepath)
+    case "jpg":
+      return getBase64TypeFromFilePath('jpg', filepath)
+    case "tif":
+    case "tiff":
+      return getBase64TypeFromFilePath('tiff', filepath)
+  }
+}
+
+let getBase64TypeFromFilePath = (type, filepath) => {
+  if (!fs.existsSync(filepath)) return null
+
+  // via https://gist.github.com/mklabs/1260228/71d62802f82e5ac0bd97fcbd54b1214f501f7e77
+  let data = fs.readFileSync(filepath).toString('base64')
+  return `data:image/${type};base64,${data}`
+}
+
+module.exports = {
+  getBase64ImageDataFromFilePath,
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -212,6 +212,28 @@ let openDialogue = () => {
   })
 }
 
+let importImagesDialogue = () => {
+  dialog.showOpenDialog(
+    {
+      title:"Import Boards", 
+      filters:[
+        {name: 'Images', extensions: ['png', 'jpg']},
+      ],
+      properties: [
+        "openFile",
+        "openDirectory",
+        "multiSelections"
+      ]
+    },
+
+    (filepaths)=>{
+      if (filepaths) {
+        mainWindow.webContents.send('insertNewBoardsWithFiles', filepaths)
+      }
+    }
+  )
+}
+
 let processFountainData = (data, create, update) => {
   let scriptData = fountain.parse(data, true)
   let locations = fountainDataParser.getLocations(scriptData.tokens)
@@ -544,6 +566,10 @@ ipcMain.on('openFile', (e, arg)=> {
 
 ipcMain.on('openDialogue', (e, arg)=> {
   openDialogue()
+})
+
+ipcMain.on('importImagesDialogue', (e, arg)=> {
+  importImagesDialogue()
 })
 
 ipcMain.on('createNew', (e, arg)=> {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -228,7 +228,29 @@ let importImagesDialogue = () => {
 
     (filepaths)=>{
       if (filepaths) {
-        mainWindow.webContents.send('insertNewBoardsWithFiles', filepaths)
+        let filepathsRecursive = []
+        let handleDirectory = (dirPath) => {
+          let innerFilenames = fs.readdirSync(dirPath)
+          for(let innerFilename of innerFilenames) {
+            var innerFilePath = path.join(dirPath, innerFilename)
+            let stats = fs.statSync(innerFilePath)
+            if(stats.isFile()) {
+              filepathsRecursive.push(innerFilePath)
+            } else if(stats.isDirectory()) {
+              handleDirectory(innerFilePath)
+            }
+          }
+        }
+        for(let filepath of filepaths) {
+          let stats = fs.statSync(filepath)
+          if(stats.isFile()) {
+            filepathsRecursive.push(filepath)
+          } else if(stats.isDirectory()) {
+            handleDirectory(filepath)
+          }
+        }
+        
+        mainWindow.webContents.send('insertNewBoardsWithFiles', filepathsRecursive)
       }
     }
   )

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -13,6 +13,13 @@ const template = [
         }
       },
       {
+        label: 'Import Storyboards',
+        accelerator: 'CmdOrCtrl+Shift+i',
+        click ( item, focusedWindow, event) {
+          ipcRenderer.send('importImagesDialogue')
+        }
+      },
+      {
         type: 'separator'
       },
       {

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -932,8 +932,11 @@ let newBoard = (position, shouldAddToUndoStack = true) => {
 let insertNewBoardsWithFiles = (filepaths) => {
   let insertionIndex = currentBoard+1
   let imageFilePromises = filepaths.map(filepath => {
-    let board = insertNewBoardDataAtPosition(insertionIndex++)
     let imageData = FileReader.getBase64ImageDataFromFilePath(filepath)
+    if(!imageData) {
+      return new Promise((fulfill)=>fulfill())
+    }
+    let board = insertNewBoardDataAtPosition(insertionIndex++)
     var image = new Image()
     image.src = imageData
 

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -930,8 +930,9 @@ let newBoard = (position, shouldAddToUndoStack = true) => {
 }
 
 let insertNewBoardsWithFiles = (filepaths) => {
+  let insertionIndex = currentBoard+1
   let imageFilePromises = filepaths.map(filepath => {
-    let board = insertNewBoardDataAtPosition(currentBoard + 1)
+    let board = insertNewBoardDataAtPosition(insertionIndex++)
     let imageData = FileReader.getBase64ImageDataFromFilePath(filepath)
     var image = new Image()
     image.src = imageData
@@ -962,6 +963,7 @@ let insertNewBoardsWithFiles = (filepaths) => {
         fulfill()
       })
     })
+
   })
 
   Promise.all(imageFilePromises)

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -963,6 +963,16 @@ let insertNewBoardsWithFiles = (filepaths) => {
         context.drawImage(image, 0, 0, image.width, image.height)
         var imageDataSized = canvas.toDataURL()
         saveDataURLtoFile(imageDataSized, board.url)
+
+        // thumbnail
+        let thumbRatio = 60/image.height
+        canvas.width = image.width = thumbRatio * image.width
+        canvas.height = image.height = thumbRatio * image.height
+        context.drawImage(image, 0, 0, image.width, image.height)
+        var imageDataSized = canvas.toDataURL()
+        let thumbPath = board.url.replace('.png', '-thumbnail.png')
+        saveDataURLtoFile(imageDataSized, thumbPath)
+
         fulfill()
       })
     })
@@ -1096,8 +1106,15 @@ let saveImageFile = () => {
   }
 }
 
+const getThumbnailSize = () => {
+  return {
+    width: Math.floor(60 * boardData.aspectRatio), 
+    height: 60
+  }
+}
+
 const updateThumbnail = imageFilePath => {
-  let width = Math.floor(60 * boardData.aspectRatio), height = 60
+  let {width, height} = getThumbnailSize()
 
   storyboarderSketchPane.sketchPane.setLayerVisible(false, 2) // HACK hardcoded
   storyboarderSketchPane.sketchPane.setLayerVisible(false, 4) // HACK hardcoded


### PR DESCRIPTION
This is a basic implementation of importing files. When you select "Import Storyboards" from the file menu (or invoke the Shift+Apple+I shortcut) you'll be presented with a file system dialog where you can select jpgs, pngs, or folders. We then add storyboards for each of the files, traversing directories recursively. During import, we resize the image to fit into the current storyboard dimensions, copy it to a new file in the images folder, generate a thumbnail, and finally save the board file.