### PR TITLE
Added support for photoshop importing.

### DIFF
--- a/src/js/files/FileReader.js
+++ b/src/js/files/FileReader.js
@@ -1,5 +1,7 @@
 const path = require('path')
 const fs = require('fs')
+const readPsd = require('ag-psd').readPsd;
+const initializeCanvas = require('ag-psd').initializeCanvas;
 
 /**
  * Retrieve a base 64 representation of an image file
@@ -18,6 +20,8 @@ let getBase64ImageDataFromFilePath = (filepath) => {
       return getBase64TypeFromFilePath('png', filepath)
     case "jpg":
       return getBase64TypeFromFilePath('jpg', filepath)
+    case "psd":
+      return getBase64TypeFromPhotoshopFilePath(filepath)
   }
 }
 
@@ -27,6 +31,40 @@ let getBase64TypeFromFilePath = (type, filepath) => {
   // via https://gist.github.com/mklabs/1260228/71d62802f82e5ac0bd97fcbd54b1214f501f7e77
   let data = fs.readFileSync(filepath).toString('base64')
   return `data:image/${type};base64,${data}`
+}
+
+let getBase64TypeFromPhotoshopFilePath = (filepath) => {
+  if (!fs.existsSync(filepath)) return null
+
+  initializeCanvas((width, height) => {
+        let canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        return canvas;
+      });
+  
+  let psd
+  try {
+    const buffer = fs.readFileSync(filepath)
+    psd = readPsd(buffer)
+  } catch(exception) {
+    console.error(exception)
+    return null
+  }
+  
+  if(!psd || !psd.children) {
+    return;
+  }
+  let canvas = document.createElement('canvas')
+  canvas.width = psd.width
+  canvas.height = psd.height
+  let ctx = canvas.getContext('2d');
+  for(let layer of psd.children) {
+    if(layer.canvas) {
+      ctx.drawImage(layer.canvas, layer.left, layer.top);
+    }
+  }
+  return canvas.toDataURL()
 }
 
 module.exports = {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -217,7 +217,7 @@ let importImagesDialogue = () => {
     {
       title:"Import Boards", 
       filters:[
-        {name: 'Images', extensions: ['png', 'jpg']},
+        {name: 'Images', extensions: ['png', 'jpg', 'psd']},
       ],
       properties: [
         "openFile",


### PR DESCRIPTION
Photoshop files are made available in the file selector, and will import along with the pngs and jpegs. There are some cases when this will fail due to limitations on the photoshop file reading library—the one I ran into during testing is trying to open a 16bit photoshop file. For now, it fails silently, and sends an error log to the console.