### PR TITLE
Import to reference layer.

### DIFF
--- a/src/js/files/FileReader.js
+++ b/src/js/files/FileReader.js
@@ -10,20 +10,26 @@ const initializeCanvas = require('ag-psd').initializeCanvas;
  * @param {Object} options
  * @returns {Object} An object with data for notes (optional), reference (optional), and main
  */
-let getBase64ImageDataFromFilePath = (filepath, options={}) => {
+let getBase64ImageDataFromFilePath = (filepath, options={importTargetLayer:"reference"}) => {
+  let {importTargetLayer} = options
   let arr = filepath.split(path.sep)
   let filename = arr[arr.length-1]
   let filenameParts =filename.toLowerCase().split('.')
   let type = filenameParts[filenameParts.length-1]
 
+  let result = {}
   switch(type) {
     case "png":
-      return { "main": getBase64TypeFromFilePath('png', filepath) }
+      result[importTargetLayer] = getBase64TypeFromFilePath('png', filepath)
+      break
     case "jpg":
-      return { "main": getBase64TypeFromFilePath('jpg', filepath) }
+      result[importTargetLayer] = getBase64TypeFromFilePath('jpg', filepath)
+      break
     case "psd":
-      return getBase64TypeFromPhotoshopFilePath(filepath, options)
+      result = getBase64TypeFromPhotoshopFilePath(filepath, options)
+      break
   }
+  return result
 }
 
 let getBase64TypeFromFilePath = (type, filepath) => {

--- a/src/js/prefs.js
+++ b/src/js/prefs.js
@@ -16,7 +16,8 @@ const defaultPrefs = {
   enableHighQualityAudio: false,
   enableTooltips: true,
   enableAspirationalMessages: true,
-  defaultBoardTiming: 2000
+  defaultBoardTiming: 2000,
+  importTargetLayer: "reference"
 }
 
 let prefs


### PR DESCRIPTION
Fixes #325.
Added support for targeting different layers on importing.
Make the thumbnail convas the correct size, then draw the image into it at its correct size.
Note that we currently read from the preference object, but the UI to update it isn't set up.