### PR TITLE
Basic implementation of canvas recording.

### DIFF
--- a/src/js/files/forked-file-writer.js
+++ b/src/js/files/forked-file-writer.js
@@ -1,0 +1,7 @@
+const fs = require('fs')
+
+process.on('message', (msg) => {
+  fs.writeFile(msg.file, msg.data, msg.options, () => {
+    
+  })
+});

--- a/src/js/utils/canvas-buffer-ouput-file.js
+++ b/src/js/utils/canvas-buffer-ouput-file.js
@@ -1,0 +1,24 @@
+const fs = require('fs')
+const { fork } = require('child_process');
+const forked = fork(__dirname+'/../files/forked-file-writer.js')
+
+class CanvasBufferOutputFileStrategy {
+  constructor(options) {
+  }
+
+  flush(buffer, pool) {
+    let i = 0;
+    while(buffer.length) {
+      let bufferData = buffer.splice(0, 1)[0]
+      let imageData = bufferData.canvas
+        .toDataURL('image/png')
+        .replace(/^data:image\/\w+;base64,/, '')
+      forked.send({ file: bufferData.metaData, data: imageData, options:'base64' })
+      if(pool) {
+        pool.push(bufferData.canvas)
+      }
+    }
+  }
+}
+
+module.exports = CanvasBufferOutputFileStrategy

--- a/src/js/utils/canvas-buffer-ouput-gif.js
+++ b/src/js/utils/canvas-buffer-ouput-gif.js
@@ -1,0 +1,38 @@
+const fs = require('fs')
+const GIFEncoder = require('gifencoder')
+
+class CanvasBufferOutputGifStrategy {
+  constructor(options) {
+    this.filepath = options.filepath || ""
+    this.width = options.width || 1600
+    this.height = options.height || 900
+  }
+
+  flush(buffer, pool) {
+    let canvas = document.createElement('canvas')
+    canvas.width = this.width
+    canvas.height = this.height
+    let context = canvas.getContext('2d')
+    context.fillStyle = 'white'
+
+    let encoder = new GIFEncoder(this.width, this.height)
+    encoder.createReadStream().pipe(fs.createWriteStream(this.filepath))
+    encoder.start()
+    encoder.setRepeat(0)   // 0 for repeat, -1 for no-repeat
+    encoder.setDelay(33)  // frame delay in ms
+    let i = 0;
+    while(buffer.length) {
+      let bufferData = buffer.splice(0, 1)[0]
+      context.fillRect(0, 0, this.width, this.height)
+      context.drawImage(bufferData.canvas, 0, 0, this.width, this.height)
+      encoder.addFrame(context)
+      if(pool) {
+        pool.push(bufferData.canvas)
+      }
+    }
+    
+    encoder.finish()
+  }
+}
+
+module.exports = CanvasBufferOutputGifStrategy

--- a/src/js/utils/canvas-buffer.js
+++ b/src/js/utils/canvas-buffer.js
@@ -1,0 +1,37 @@
+const CanvasBufferOutputFileStrategy = require('./canvas-buffer-ouput-file.js')
+
+class CanvasBuffer {
+  constructor(options) {
+    this.canvasPool = []
+    this.buffer = []
+    this.strategy = options && options.strategy || new CanvasBufferOutputFileStrategy()
+  }
+
+  addToBuffer(sourceCanvas, metaData) {
+    // let start = Date.now()
+    
+    let bufferCanvas = this._getCanvasForBuffer()
+    bufferCanvas.width = sourceCanvas.width
+    bufferCanvas.height = sourceCanvas.height
+    let bufferContext = bufferCanvas.getContext('2d')
+    bufferContext.drawImage(sourceCanvas, 0, 0, sourceCanvas.width, sourceCanvas.height);
+    this.buffer.push({canvas: bufferCanvas, metaData: metaData})
+
+    // let end = Date.now()
+    // console.log(`${end} - ${start} = ${end-start}`)
+  }
+
+  flushBuffer() {
+    this.strategy.flush(this.buffer, this.canvasPool)
+  }
+
+  _getCanvasForBuffer() {
+    if(this.canvasPool.length > 0) {
+      return this.canvasPool.splice(0, 1)[0]
+    }
+
+    return document.createElement('canvas')
+  }
+}
+
+module.exports = CanvasBuffer

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -41,6 +41,13 @@ const LAYER_INDEX_REFERENCE = 0
 const LAYER_INDEX_MAIN = 1
 const LAYER_INDEX_NOTES = 2
 
+const CanvasBufferOutputFileStrategy = require('../utils/canvas-buffer-ouput-file.js')
+const CanvasBufferOutputGifStrategy = require('../utils/canvas-buffer-ouput-gif.js')
+const CanvasBuffer = require('../utils/canvas-buffer.js')
+let screenRecordingBuffer
+let screenRecordingFrameNum = 0
+let isRecording = false
+
 let boardFilename
 let boardPath
 let boardData
@@ -382,7 +389,12 @@ let loadBoardUI = ()=> {
 
     saveThumbnailFile(currentBoard).then(index => updateThumbnailDisplay(index))
 
-    // TODO save progress image
+    // save progress image
+    if(isRecording) {
+      let snapshotCanvas = storyboarderSketchPane.sketchPane.getLayerCanvas(1)
+      let filepath = path.join(boardPath, 'images', `recording-${screenRecordingFrameNum++}.png`)
+      screenRecordingBuffer.addToBuffer(snapshotCanvas, filepath)
+    }
   })
   
   storyboarderSketchPane.on('lineMileage', value => {
@@ -2526,6 +2538,20 @@ window.onkeydown = (e)=> {
           e.preventDefault()
         }
         break
+      // r
+      // case 82:
+      //   if(isRecording) {
+      //     screenRecordingBuffer.flushBuffer()
+      //     isRecording = false
+      //   } else {
+      //     isRecording = true
+      //     let filepath = path.join(boardPath, 'images', `recording-${screenRecordingFrameNum}.gif`)
+      //     let strategy = new CanvasBufferOutputGifStrategy({filepath: filepath, width: 400, height: 225})
+      //     if (e.metaKey || e.ctrlKey) {
+      //       strategy = new CanvasBufferOutputFileStrategy()
+      //     }
+      //     screenRecordingBuffer = new CanvasBuffer({strategy})
+      //   }
       // V
       case 86:
         if (e.metaKey || e.ctrlKey) {


### PR DESCRIPTION
In trying to keep acceptable performance while drawing, the best way that I've found so far is to copy the canvas into a buffer, postponing any converstion and file writing until no drawing is happening. The new CanvasBuffer object, and its output strategies help manage this.

GH-387