### PR TITLE
Handle dropped files to the welcome and main windows. 

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -374,6 +374,32 @@ let loadBoardUI = ()=> {
     setTimeout(()=>{storyboarderSketchPane.resize()}, 500)
   })
 
+  window.ondragover = () => { return false }
+  window.ondragleave = () => { return false }
+  window.ondragend = () => { return false }
+
+  window.ondrop = e => {
+    e.preventDefault()
+    if(!e || !e.dataTransfer || !e.dataTransfer.files || !e.dataTransfer.files.length) {
+      return
+    }
+    let hasStoryboarderFile = false
+    let filepaths = []
+    for(let file of e.dataTransfer.files) {
+      if(file.name.indexOf(".storyboarder") > -1) {
+        hasStoryboarderFile = true
+        ipcRenderer.send('openFile', file.path)
+        break
+      } else {
+        filepaths.push(file.path)
+      }
+    }
+
+    if(!hasStoryboarderFile) {
+      insertNewBoardsWithFiles(filepaths)
+    }
+  }
+
   storyboarderSketchPane.on('addToUndoStack', layerIndices => {
     storeUndoStateForImage(true, layerIndices)
   })

--- a/src/js/window/welcome-window.js
+++ b/src/js/window/welcome-window.js
@@ -106,3 +106,20 @@ sfx.init()
 ipcRenderer.on('updateRecentDocuments', (event, args)=>{
   updateRecentDocuments()
 })
+
+window.ondragover = () => { return false }
+window.ondragleave = () => { return false }
+window.ondragend = () => { return false }
+window.ondrop = e => {
+  e.preventDefault()
+  if(!e || !e.dataTransfer || !e.dataTransfer.files || !e.dataTransfer.files.length) {
+    return
+  }
+  for(let file of e.dataTransfer.files) {
+    if(file.name.indexOf(".storyboarder") > -1) {
+      hasStoryboarderFile = true
+      ipcRenderer.send('openFile', file.path)
+      break
+    }
+  }
+}


### PR DESCRIPTION
If a storyboarder file is one of the files dropped, opening the project takes precedence, i.e. all other files are ignored.

Closes GH-366