### PR TITLE
Prevent Tooltips from showing if Sprint Sketch or Color Picker are active

### DIFF
--- a/src/js/window/color-picker.js
+++ b/src/js/window/color-picker.js
@@ -2,6 +2,7 @@ const {ipcRenderer} = require('electron')
 const EventEmitter = require('events').EventEmitter
 const Tether = require('tether')
 const Color = require('color-js')
+const tooltips = require('./tooltips')
 
 class ColorPicker extends EventEmitter {
   constructor () {
@@ -157,10 +158,14 @@ class ColorPicker extends EventEmitter {
   
   fadeIn () {
     this.innerEl.classList.add('appear-anim')
+
+    tooltips.closeAll()
+    tooltips.setIgnore(document.querySelector('#toolbar-current-color'), true)
   }
 
   fadeOut () {
     this.innerEl.classList.remove('appear-anim')
+    tooltips.setIgnore(document.querySelector('#toolbar-current-color'), false)
   }
   
   hasChild (child) {

--- a/src/js/window/pomodoro-timer-view.js
+++ b/src/js/window/pomodoro-timer-view.js
@@ -7,6 +7,7 @@ const userDataHelper = require('../files/user-data-helper.js')
 const sfx = require('../wonderunit-sound.js')
 const moment = require('moment')
 const fs = require('fs')
+const tooltips = require('./tooltips')
 
 class PomodorTimerView extends EventEmitter {
   constructor() {
@@ -268,10 +269,15 @@ class PomodorTimerView extends EventEmitter {
 
   fadeIn () {
     this.innerEl.classList.add('appear-anim')
+
+    tooltips.closeAll()
+    document.querySelector('#toolbar-pomodoro-rest').dataset.tooltipIgnore = true
   }
 
   fadeOut () {
     this.innerEl.classList.remove('appear-anim')
+
+    delete document.querySelector('#toolbar-pomodoro-rest').dataset.tooltipIgnore
   }
 
   onPointerLeave (event) {

--- a/src/js/window/pomodoro-timer-view.js
+++ b/src/js/window/pomodoro-timer-view.js
@@ -271,13 +271,12 @@ class PomodorTimerView extends EventEmitter {
     this.innerEl.classList.add('appear-anim')
 
     tooltips.closeAll()
-    document.querySelector('#toolbar-pomodoro-rest').dataset.tooltipIgnore = true
+    tooltips.setIgnore(document.querySelector('#toolbar-pomodoro-rest'), true)
   }
 
   fadeOut () {
     this.innerEl.classList.remove('appear-anim')
-
-    delete document.querySelector('#toolbar-pomodoro-rest').dataset.tooltipIgnore
+    tooltips.setIgnore(document.querySelector('#toolbar-pomodoro-rest'), false)
   }
 
   onPointerLeave (event) {

--- a/src/js/window/tooltips.js
+++ b/src/js/window/tooltips.js
@@ -75,6 +75,14 @@ const setupTooltipForElement = (el) => {
 
 const closeAll = () => tooltips.forEach(t => t.close())
 
+const setIgnore = (el, value) => {
+  if (value) {
+    el.dataset.tooltipIgnore = true
+  } else {
+    delete el.dataset.tooltipIgnore
+  }
+}
+
 const init = () => {
   getPrefs('pref editor')
   if (!enableTooltips) return false
@@ -90,5 +98,6 @@ module.exports = {
   setupTooltipForElement,
   housekeeping,
   getPrefs,
+  setIgnore,
   closeAll
 }

--- a/src/js/window/tooltips.js
+++ b/src/js/window/tooltips.js
@@ -73,6 +73,8 @@ const setupTooltipForElement = (el) => {
   return tooltip
 }
 
+const closeAll = () => tooltips.forEach(t => t.close())
+
 const init = () => {
   getPrefs('pref editor')
   if (!enableTooltips) return false
@@ -87,5 +89,6 @@ module.exports = {
   init,
   setupTooltipForElement,
   housekeeping,
-  getPrefs
+  getPrefs,
+  closeAll
 }

--- a/src/js/window/tooltips.js
+++ b/src/js/window/tooltips.js
@@ -64,7 +64,7 @@ const setupTooltipForElement = (el) => {
   // HACK! force close immediately unless we allow tooltips in preferences
   tooltip.drop.on('open', () => {
     sfx.playEffect('metal')
-    if (!enableTooltips) {
+    if (!enableTooltips || el.dataset.tooltipIgnore) {
       tooltip.close()
     }
   })


### PR DESCRIPTION
Fixes https://github.com/wonderunit/storyboarder/issues/497