### PR TITLE
Truncate right sidebar filename

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1914,7 +1914,9 @@ const renderStats = () => {
   //
   // right stats
   //
-  document.querySelector('#right-stats .stats-primary').innerHTML = util.truncateMiddle(path.basename(boardFilename, path.extname(boardFilename))) + '.storyboarder'
+  let rightStatsPrimaryEl = document.querySelector('#right-stats .stats-primary')
+  rightStatsPrimaryEl.innerHTML = util.truncateMiddle(path.basename(boardFilename, path.extname(boardFilename))) + '.storyboarder'
+  rightStatsPrimaryEl.title = path.basename(boardFilename)
 
   // if (scriptData) {
   //   let numScenes = scriptData.filter(data => data.type == 'scene').length

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1914,7 +1914,7 @@ const renderStats = () => {
   //
   // right stats
   //
-  document.querySelector('#right-stats .stats-primary').innerHTML = path.basename(boardFilename)
+  document.querySelector('#right-stats .stats-primary').innerHTML = util.truncateMiddle(path.basename(boardFilename, path.extname(boardFilename))) + '.storyboarder'
 
   // if (scriptData) {
   //   let numScenes = scriptData.filter(data => data.type == 'scene').length


### PR DESCRIPTION
Fixes #437 

Sets an upper limit for character count of the displayed filename. Does not update dynamically with window width yet. Using HTML title for tooltip.