### PR TITLE
Fountain import fixes

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -559,7 +559,7 @@ let loadStoryboarderWindow = (filename, scriptData, locations, characters, board
     frame: false,
     resizable: false
   })
-  loadingStatusWindow.loadURL(`file://${__dirname}/../loading-status.html?name=${projectName}`)
+  loadingStatusWindow.loadURL(`file://${__dirname}/../loading-status.html?name=${encodeURIComponent(projectName)}`)
   loadingStatusWindow.once('ready-to-show', () => {
     loadingStatusWindow.show()
   })


### PR DESCRIPTION
In script-based projects, when switching to a scene, the first board was not initialized.
The thumbnail drawer tried to render an empty board list.
Caused errors like:
```
Uncaught TypeError: Cannot read property 'classList' of null
In file: […]/storyboarder/src/js/window/main-window.js#1811:74
```
```
Uncaught TypeError: Cannot read property 'url' of undefined
In file: […]/storyboarder/src/js/window/main-window.js#1292:22
```

Also fixed an issue with the script-based project title in the loading screen.

Fixes #675, #685