### PR TITLE
Fix bugs related to missing images

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -3673,14 +3673,14 @@ let pasteBoards = () => {
 
     insertAt = insertAt + 1 // actual splice point
 
-    let boards = migrateBoardData(newBoards, insertAt)
+    migrateBoardData(newBoards, insertAt)
 
     // insert boards from clipboard data
     Promise.resolve().then(() => {
       // store the "before" state
       storeUndoStateForScene(true)
 
-      return insertBoards(boardData.boards, insertAt, boards, { layerDataByBoardIndex })
+      return insertBoards(boardData.boards, insertAt, newBoards, { layerDataByBoardIndex })
     }).then(() => {
       markBoardFileDirty()
       storeUndoStateForScene()
@@ -3748,7 +3748,7 @@ const insertBoards = (dest, insertAt, boards, { layerDataByBoardIndex }) => {
       resolve()
     }).catch(err => {
       console.log(err)
-      reject()
+      reject(err)
     })
   })
 }
@@ -3858,9 +3858,8 @@ const importFromWorksheet = async (imageArray) => {
   }
 }
 
-
-
-const migrateBoardData = (newBoards, insertAt) => {
+// NOTE: migrateBoardData mutates the object passed to it
+const migrateBoardData = (newBoards, insertAt = 0) => {
   // assign a new uid to the board, regardless of source
   newBoards = newBoards.map(boardModel.assignUid)
 
@@ -3869,7 +3868,7 @@ const migrateBoardData = (newBoards, insertAt) => {
 
   // update board layers filenames based on index
   newBoards = newBoards.map((board, index) =>
-    boardModel.updateUrlsFromIndex(board, index))
+    boardModel.updateUrlsFromIndex(board, insertAt + index))
 
   return newBoards
 }

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -2405,16 +2405,21 @@ let renderThumbnailDrawer = ()=> {
       sfx.playEffect('metal')
     })
     contextMenu.on('add', () => {
-      newBoard().then(() => {
-        gotoBoard(currentBoard + 1)
+      newBoard().then(index => {
+        gotoBoard(index)
         ipcRenderer.send('analyticsEvent', 'Board', 'new')
-      })
+      }).catch(err => console.error(err))
     })
     contextMenu.on('delete', () => {
       deleteBoards()
     })
     contextMenu.on('duplicate', () => {
       duplicateBoard()
+        .then(index => {
+          gotoBoard(index)
+          ipcRenderer.send('analyticsEvent', 'Board', 'duplicate')
+        })
+        .catch(err => console.error(err))
     })
     contextMenu.on('copy', () => {
       copyBoards()
@@ -2520,10 +2525,10 @@ let renderThumbnailButtons = () => {
       let eventMouseOut = document.createEvent('MouseEvents')
       eventMouseOut.initMouseEvent('mouseout', true, true)
       el.dispatchEvent(eventMouseOut)
-      newBoard(boardData.boards.length).then(() => {
-        gotoBoard(boardData.boards.length)
-      })
-      ipcRenderer.send('analyticsEvent', 'Board', 'new')
+      newBoard(boardData.boards.length).then(index => {
+        gotoBoard(index)
+        ipcRenderer.send('analyticsEvent', 'Board', 'new')
+      }).catch(err => console.error(err))
     })
 
     // NOTE tooltips.setupTooltipForElement checks prefs each time, e.g.:
@@ -3270,16 +3275,16 @@ ipcRenderer.on('newBoard', (event, args)=>{
   if (!textInputMode) {
     if (args > 0) {
       // insert after
-      newBoard().then(() => {
-        gotoBoard(currentBoard + 1)
+      newBoard().then(index => {
+        gotoBoard(index)
         ipcRenderer.send('analyticsEvent', 'Board', 'new')
-      })
+      }).catch(err => console.error(err))
     } else {
-      // inset before
+      // insert before
       newBoard(currentBoard).then(() => {
         gotoBoard(currentBoard)
         ipcRenderer.send('analyticsEvent', 'Board', 'new')
-      })
+      }).catch(err => console.error(err))
     }
   }
   ipcRenderer.send('analyticsEvent', 'Board', 'new')
@@ -4345,7 +4350,11 @@ ipcRenderer.on('deleteBoards', (event, args)=>{
 ipcRenderer.on('duplicateBoard', (event, args)=>{
   if (!textInputMode) {
     duplicateBoard()
-    ipcRenderer.send('analyticsEvent', 'Board', 'duplicate')
+      .then(index => {
+        gotoBoard(index)
+        ipcRenderer.send('analyticsEvent', 'Board', 'duplicate')
+      })
+      .catch(err => console.error(err))
   }
 })
 

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -2153,6 +2153,7 @@ let nextScene = ()=> {
       saveBoardFile()
       currentScene++
       loadScene(currentScene).then(() => {
+        verifyScene()
         renderScript()
         renderScene()
       })
@@ -2178,6 +2179,7 @@ let previousScene = ()=> {
       currentScene--
       currentScene = Math.max(0, currentScene)
       loadScene(currentScene).then(() => {
+        verifyScene()
         renderScript()
         renderScene()
       })
@@ -2629,6 +2631,7 @@ let renderScenes = ()=> {
       if (currentScene !== Number(e.target.dataset.node)) {
         currentScene = Number(e.target.dataset.node)
         loadScene(currentScene).then(() => {
+          verifyScene()
           renderScript()
           renderScene()
         })
@@ -4178,6 +4181,7 @@ const applyUndoStateForScene = (state) => {
     saveBoardFile()
     currentScene = getSceneNumberBySceneId(state.sceneId)
     loadScene(currentScene).then(() => {
+      verifyScene()
       renderScript()
     })
   }
@@ -4217,6 +4221,7 @@ const applyUndoStateForImage = (state) => {
     // go to the requested scene
     currentScene = getSceneNumberBySceneId(state.sceneId)
     loadScene(currentScene).then(() => {
+      verifyScene()
       renderScript()
     })
   }

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -182,6 +182,8 @@ const load = async (event, args) => {
     loadBoardUI()
     await updateBoardUI()
 
+    verifyScene()
+
     log({ type: 'progress', message: 'Preparing to display' })
 
     resize()
@@ -385,6 +387,25 @@ const commentOnLineMileage = (miles) => {
       break
   }
   notifications.notify({message: message.join(' '), timing: 10})
+}
+
+const verifyScene = () => {
+  // find all used files
+  const flatten = arr => Array.prototype.concat(...arr)
+  const usedFiles = flatten(boardData.boards.map(board => ([
+    ...boardModel.boardOrderedLayerFilenames(board).filenames,
+    boardModel.boardFilenameForThumbnail(board),
+    ...(board.link ? [board.link] : [])
+  ])))
+
+  // notify about any missing file
+  for (let filename of usedFiles) {
+    if (!fs.existsSync(path.join(boardPath, 'images', filename))) {
+      let message = `[WARNING] Missing File\n${filename}`
+      console.warn(message)
+      notifications.notify({ message })
+    }
+  }
 }
 
 let loadBoardUI = ()=> {

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1327,6 +1327,7 @@ let saveImageFile = async () => {
   // are we still drawing?
   if (storyboarderSketchPane.getIsDrawingOrStabilizing()) {
     // wait, then retry
+    console.warn('Still drawing. Not ready to save yet. Retry in 5s')
     imageFileDirtyTimer = setTimeout(saveImageFile, 5000)
     isSavingImageFile = false
     return


### PR DESCRIPTION
Features:
- [x] Warn artist if they open a Storyboarder scene that has missing images
- [x] Prevent "New Board" and "Duplicate Board" if images are not yet saved
- [x] Fix a bug that caused duplicated boards to always save with index 1 in their filename
- [x] Better error reporting

Related to #708