### PR TITLE
Ensure thumbnails update when thumbnail files change

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1743,7 +1743,8 @@ const updateThumbnailDisplayFromFile = index => {
   // does it exist in the thumbnail drawer already?
   if (el) {
     let imageFilePath = path.join(boardPath, 'images', boardModel.boardFilenameForThumbnail(boardData.boards[index]))
-    el.src = imageFilePath + '?' + Date.now()
+    let src = imageFilePath + '?' + getEtag(imageFilePath)
+    el.src = src
   }
 }
 
@@ -2453,7 +2454,8 @@ let renderThumbnailDrawer = ()=> {
     try {
       if (fs.existsSync(imageFilename)) {
         html.push('<div class="top">')
-        html.push('<img src="' + imageFilename + '" height="60" width="' + thumbnailWidth + '">')
+        let src = imageFilename + '?' + getEtag(imageFilename)
+        html.push('<img src="' + src + '" height="60" width="' + thumbnailWidth + '">')
         html.push('</div>')
       } else {
         // blank image
@@ -4346,6 +4348,20 @@ const createSizedContext = size => {
 const fillContext = (context, fillStyle = 'white') => {
   context.fillStyle = fillStyle
   context.fillRect(0, 0, context.canvas.width, context.canvas.height)
+}
+
+const getEtag = filename => {
+  try {
+    let s = fs.statSync(filename)
+    let etag = s.dev + '-' + s.ino + '-' + s.mtime.getTime()
+    return etag
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.warn('File not found', filename)
+    } else {
+      throw err
+    }
+  }
 }
 
 ipcRenderer.on('setTool', (e, arg)=> {


### PR DESCRIPTION
- [x] Updates thumbnail if PSD for current board changes
- [x] Updates thumbnail if PSD for non-current board changes

Stores a key in memory, per thumbnail, and updates key when the watcher indicates a change. Uses key as cache buster when loading image. Default key is 0 (no change since first loaded).

Fixes #739