### PR TITLE
Reload from linked PSD(s) when window receives focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "storyboarder",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storyboarder",
   "productName": "Storyboarder",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "The fastest way to storyboard.",
   "main": "src/js/main.js",
   "scripts": {

--- a/src/css/preferences.css
+++ b/src/css/preferences.css
@@ -42,6 +42,7 @@
   margin-top: 0.5rem;
   opacity: 0.5;
   font-size: 87.5%;
+  line-height: 1.4;
  }
   
  sup {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -703,6 +703,10 @@ let loadStoryboarderWindow = (filename, scriptData, locations, characters, board
     mainWindow.webContents.on('devtools-closed', event => { mainWindow.webContents.send('devtools-closed') })
   }
 
+  mainWindow.on('focus', () => {
+    mainWindow.webContents.send('focus')
+  })
+
   // via https://github.com/electron/electron/blob/master/docs/api/web-contents.md#event-will-prevent-unload
   //     https://github.com/electron/electron/pull/9331
   //

--- a/src/js/prefs.js
+++ b/src/js/prefs.js
@@ -25,6 +25,7 @@ const defaultPrefs = {
   enableStabilizer: true,
   enableAnalytics: true,
   enableAutoSave: true,
+  enableAutomaticLinkedFileReload: true,
 
   // notifications
   allowNotificationsForLineMileage: true,

--- a/src/js/prefs.js
+++ b/src/js/prefs.js
@@ -25,7 +25,7 @@ const defaultPrefs = {
   enableStabilizer: true,
   enableAnalytics: true,
   enableAutoSave: true,
-  enableAutomaticLinkedFileReload: true,
+  enableForcePsdReloadOnFocus: true,
 
   // notifications
   allowNotificationsForLineMileage: true,

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1679,6 +1679,9 @@ let openInEditor = async () => {
 }
 const onLinkedFileChange = async (eventType, filepath, stats) => {
   console.log('onLinkedFileChange', eventType, filepath, stats)
+
+  if (!prefsModule.getPrefs()['enableAutomaticLinkedFileReload']) return
+
   if (eventType !== 'change') {
     // ignore `add` events, etc
     // we only care about `change` events (explicit save events)
@@ -4933,6 +4936,8 @@ ipcRenderer.on('exportZIP', (event, args) => exportZIP())
 ipcRenderer.on('reloadScript', (event, args) => reloadScript(args))
 
 ipcRenderer.on('focus', async event => {
+  if (prefsModule.getPrefs()['enableAutomaticLinkedFileReload']) return
+
   // update watched files
   let watched = watcher.getWatched()
   for (let dir of Object.keys(watched)) {

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1680,8 +1680,6 @@ let openInEditor = async () => {
 const onLinkedFileChange = async (eventType, filepath, stats) => {
   console.log('onLinkedFileChange', eventType, filepath, stats)
 
-  if (!prefsModule.getPrefs()['enableAutomaticLinkedFileReload']) return
-
   if (eventType !== 'change') {
     // ignore `add` events, etc
     // we only care about `change` events (explicit save events)
@@ -4936,7 +4934,7 @@ ipcRenderer.on('exportZIP', (event, args) => exportZIP())
 ipcRenderer.on('reloadScript', (event, args) => reloadScript(args))
 
 ipcRenderer.on('focus', async event => {
-  if (prefsModule.getPrefs()['enableAutomaticLinkedFileReload']) return
+  if (!prefsModule.getPrefs()['enableForcePsdReloadOnFocus']) return
 
   // update watched files
   let watched = watcher.getWatched()

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -53,15 +53,17 @@
         <div class="preferences-input">
           <input
             type="checkbox"
-            name="enableAutomaticLinkedFileReload"
-            id="enableAutomaticLinkedFileReload" />
+            name="enableForcePsdReloadOnFocus"
+            id="enableForcePsdReloadOnFocus" />
 
-          <label for="enableAutomaticLinkedFileReload">
-            <span></span>Reload linked boards automatically when PSD changes
+          <label for="enableForcePsdReloadOnFocus">
+            <span></span>Force reload of watched PSD when Storyboarder regains focus
           </label>
           <div class="preferences-hint">
-            Disable this option if automatic reload isn’t working.<br/>
-            If disabled, boards reload from PSD manually when Storyboarder regains focus.
+            Enable if working from a network drive.
+            Disable to improve performance when switching between
+            Storyboarder and other apps. When disabled, Storyboarder only 
+            watches PSD files in the background (which is not supported on all computers).
           </div>
         </div>
 

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -52,6 +52,21 @@
 
         <div class="preferences-input">
           <input
+            type="checkbox"
+            name="enableAutomaticLinkedFileReload"
+            id="enableAutomaticLinkedFileReload" />
+
+          <label for="enableAutomaticLinkedFileReload">
+            <span></span>Reload linked boards automatically when PSD changes
+          </label>
+          <div class="preferences-hint">
+            Disable this option if automatic reload isn’t working.<br/>
+            If disabled, boards reload from PSD manually when Storyboarder regains focus.
+          </div>
+        </div>
+
+        <div class="preferences-input">
+          <input
             type="number"
             name="defaultBoardTiming"
             id="defaultBoardTiming" />


### PR DESCRIPTION
- For all active linked PSDs (where artist has, during this session, clicked the "Edit in Photoshop" button)...
- ... when the main workspace window receives focus
- ... copy layer images to the respective board from the source PSD

- [x] Make a preference to disable forced reload on focus
