### PR TITLE
Quick brush resize using Ctrl+Click in sketch pane

### DIFF
--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -831,7 +831,9 @@ class DrawingStrategy {
       this.startAt = [pointerPosition.x, pointerPosition.y]
     }
     this.container.lineMileageCounter.reset()
-    this.container.sketchPane.down(pointerPosition.x, pointerPosition.y, e.pointerType === "pen" ? e.pressure : 1)
+    if (!this.container.toolbar.getIsQuickResizing()) {
+      this.container.sketchPane.down(pointerPosition.x, pointerPosition.y, e.pointerType === "pen" ? e.pressure : 1)
+    }
     document.addEventListener('pointermove', this.container.canvasPointerMove)
     document.addEventListener('pointerup', this.container.canvasPointerUp)
     this.container.emit('pointerdown', pointerPosition.x, pointerPosition.y, e.pointerType === "pen" ? e.pressure : 1, e.pointerType)
@@ -856,7 +858,9 @@ class DrawingStrategy {
     this.startAt = null
     
     let pointerPosition = this.container.getRelativePosition(e.clientX, e.clientY)
-    this.container.sketchPane.up(pointerPosition.x, pointerPosition.y, e.pointerType === "pen" ? e.pressure : 1)
+    if (!this.container.toolbar.getIsQuickResizing()) {
+      this.container.sketchPane.up(pointerPosition.x, pointerPosition.y, e.pointerType === "pen" ? e.pressure : 1)
+    }
     this.container.emit('lineMileage', this.container.lineMileageCounter.get())
     document.removeEventListener('pointermove', this.container.canvasPointerMove)
     document.removeEventListener('pointerup', this.container.canvasPointerUp)

--- a/src/js/window/toolbar.js
+++ b/src/js/window/toolbar.js
@@ -143,6 +143,10 @@ class Toolbar extends EventEmitter {
       this.state = initialState
     }
 
+    // Do not recover isQuickResizing from saved toolbarState
+    // (Ths is a temporary state)
+    this.isQuickResizing = initialState.isQuickResizing;
+
 
     this.el = el
     this.swatchTimer = null
@@ -212,6 +216,7 @@ class Toolbar extends EventEmitter {
   }
 
   setIsQuickResizing (value) {
+    console.log("setIsQuickResizing: " + value)
     this.state.isQuickResizing = value
   }
 

--- a/src/js/window/toolbar.js
+++ b/src/js/window/toolbar.js
@@ -23,6 +23,7 @@ const initialState = {
 
   brush: null,
   isQuickErasing: false,
+  isQuickResizing: false,
 
   brushes: {
     [BRUSH_PENCIL]: {
@@ -170,8 +171,6 @@ class Toolbar extends EventEmitter {
   }
 
   changeBrushSize (direction, fine = false) {
-    let min = 1
-    let max = 256
     let currSize = this.state.brushes[this.state.brush].size
 
     if (fine) {
@@ -184,10 +183,17 @@ class Toolbar extends EventEmitter {
       }
     }
 
-    if (currSize < min) currSize = min
-    if (currSize > max) currSize = max
+    setBrushSize (currSize)
+  }
 
-    this.state.brushes[this.state.brush].size = currSize
+  setBrushSize (size) {
+    let min = 1
+    let max = 256
+    
+    if (size < min) size = min
+    if (size > max) size = max
+
+    this.state.brushes[this.state.brush].size = size
 
     this.emit('brush:size', this.getBrushOptions().size)
     this.render()
@@ -199,6 +205,14 @@ class Toolbar extends EventEmitter {
 
   setIsQuickErasing (value) {
     this.state.isQuickErasing = value
+  }
+
+  getIsQuickResizing () {
+    return this.state.isQuickResizing
+  }
+
+  setIsQuickResizing (value) {
+    this.state.isQuickResizing = value
   }
 
   changeCurrentColor (color) {


### PR DESCRIPTION
This PR enables quick and intuitive resizing of the brush directly in the sketch pane using Control+click.

Known limitations:

 * Displayed cursor jumps at the end of resizing. We would need a way to move mouse from code to fix this properly. Is there a way to do so?

 * There is a quatum issue occuring sometime when starting, likely due to the saving of the toolbar state. This sets the app in an inconsistent state though we override the value of `state.isQuickResizing` in Toolbar's constructor. We need to discuss that.

 * It'd be nice to augment the gizmo with a little indicator of the mouse position while resizing the brush, but the code of `SketchPane.createAlphaThresholdBorder()` is still a bit obscure to us (and stuffed with some TODOs of yours). Should we move the cursor drawing into the strategy?

 * We should eventually make it resize the eraser when using right click.