### PR TITLE
Allow OpenToonz compatible Image Export

### DIFF
--- a/src/js/models/board.js
+++ b/src/js/models/board.js
@@ -7,7 +7,7 @@ const boardFileImageSize = boardFileData =>
     : [900, 900 / boardFileData.aspectRatio]
 
 const boardFilenameForExport = (board, index, basenameWithoutExt) =>
-  `${basenameWithoutExt}-board-` + util.zeroFill(5, index + 1) + '.png'
+  `${basenameWithoutExt}-board.` + util.zeroFill(4, index + 1) + '.png'
 
 const boardFilenameForThumbnail = board =>
   board.url.replace('.png', '-thumbnail.png')


### PR DESCRIPTION
Using a dot instead of a dash before the image numbers is the preferred format for Maya, Nuke and OpenToonz.  