### PR TITLE
Add a compatibility setting to disable detection of pen eraser mode

### DIFF
--- a/src/js/prefs.js
+++ b/src/js/prefs.js
@@ -38,7 +38,8 @@ const defaultPrefs = {
     skipBlankBoards: true
   },
 
-  enableBoardAudition: true
+  enableBoardAudition: true,
+  disablePenEraserDetection: false
 }
 
 // For slow computers, override the defaults here.

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -15,6 +15,7 @@ const { LAYER_NAME_BY_INDEX } = require('../constants')
 const prefsModule = require('electron').remote.require('./prefs')
 const enableBrushCursor = prefsModule.getPrefs('main')['enableBrushCursor']
 const enableStabilizer = prefsModule.getPrefs('main')['enableStabilizer']
+const disablePenEraserDetection = prefsModule.getPrefs('main')['disablePenEraserDetection']
 
 /**
  *  Wrap the SketchPane component with features Storyboarder needs
@@ -790,7 +791,7 @@ class DrawingStrategy {
     this.container.isPointerDown = true
 
     // via https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#Determining_button_states
-    if (e.buttons == 32 || e.buttons == 2) {
+    if (!disablePenEraserDetection && (e.buttons == 32 || e.buttons == 2)) {
       this.container.isEraseButtonActive = true
     } else {
       this.container.isEraseButtonActive = false
@@ -819,7 +820,7 @@ class DrawingStrategy {
     this.container.isPointerDown = false
 
     // via https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#Determining_button_states
-    if (e.buttons == 32 || e.buttons == 2) {
+    if (!disablePenEraserDetection && (e.buttons == 32 || e.buttons == 2)) {
       this.container.isEraseButtonActive = true
     } else {
       this.container.isEraseButtonActive = false

--- a/src/preferences.html
+++ b/src/preferences.html
@@ -238,6 +238,23 @@
         
       </div>
 
+      <div class="preferences-fieldset">
+        <h2 class="preferences-subhead">Compatibility settings</h2>
+        <div class="preferences-hint" style="margin: 0 0 24px">
+          Advanced settings for compatibility issues with your hardware.
+        </div>
+        <div class="preferences-input">
+          <input
+                  type="checkbox"
+                  name="disablePenEraserDetection"
+                  id="disablePenEraserDetection" />
+
+          <label for="disablePenEraserDetection">
+            <span></span>Disable detection of the eraser mode of your pen
+          </label>
+        </div>
+      </div>
+
       <div id="storyboardersAccount" class="preferences-fieldset">
         <div class="preferences-input">
           <a id="signOut" class="button" href="#">


### PR DESCRIPTION
I have come across a graphic tablet that has a pen without any eraser mode, but that report all pen contact as being done with the eraser button pressed. As a result, all drawings are erasure, which made such tablet unusable with Storyboarder.

This small pull request add a compatibility section to the preferences pane with an option to disable the detection of the pen eraser mode. This setting is later used to prevent such detection in the sketch pane.

I would be grateful if you could integrate this small improvement.
With kind regards,

Denis Gervalle