### PR TITLE
New Sketchpane: Undo/Redo Performance Improvements

### DIFF
--- a/src/js/undo-stack.js
+++ b/src/js/undo-stack.js
@@ -65,7 +65,7 @@ class UndoList {
 
     if (this.debugMode) this.print()
   }
-  
+
   redo () {
     const { past, present, future } = this.state
 
@@ -132,11 +132,13 @@ class UndoList {
       document.body.appendChild(this.debugEl)
     }
 
-    let clear = () =>
+    let clear = () => {
       this.debugEl.innerHTML = ''
+    }
 
-    let trace = (...args) =>
+    let trace = (...args) => {
       this.debugEl.innerHTML += '<div>' + args.join(' ') + '</div>'
+    }
 
     let boardIndexes = arr =>
       arr.map(b => parseInt(b.url.replace('board-', ''), 10)).join(', ')
@@ -145,16 +147,17 @@ class UndoList {
       util.isUndefined(value) ? 'n/a' : value
 
     let describe = state => {
-      if (state.type == 'image') {
+      if (state.type === 'image') {
         let layersDesc = state.layers.map(layerData =>
-          `index: ${layerData.index} id:${layerData.source.id}`)
+          `index: ${layerData.index}`)
+        // `index: ${layerData.index} id:${layerData.source.id}`)
         let desc = `
           scene: ${stringOf(state.sceneId)} 
           board: ${stringOf(state.boardIndex)} 
           layers: [ ${layersDesc.join(', ')} ]
         `
         return [state.type, desc.replace(/\s+/g, ' ')]
-      } else if (state.type == 'scene') {
+      } else if (state.type === 'scene') {
         return [state.type, boardIndexes(state.sceneData.boards)].join(' ')
       }
     }
@@ -178,20 +181,25 @@ let undoList = new UndoList()
 // determine if image state A is equal to state B
 const imageStateContextsEqual = (a, b) => {
   if (
-    a && b &&                                               // are both states present?
+    // are both states present?
+    a && b &&
 
-    a.type == 'image' &&                                    // are they both image states?
-    b.type == 'image' &&
+    // are they both image states?
+    a.type === 'image' &&
+    b.type === 'image' &&
 
-    a.sceneId == b.sceneId &&                               // are they for the same board on the same scene?
-    a.boardIndex == b.boardIndex &&
+    // are they for the same board on the same scene?
+    a.sceneId === b.sceneId &&
+    a.boardIndex === b.boardIndex &&
 
-    a.layers.length == b.layers.length                      // do they have the same number of layers?
+    // do they have the same number of layers?
+    a.layers.length === b.layers.length
   ) {
     // are the layers the same?
     for (let n = 0; n < a.layers.length; n++) {
       if (
-        a.layers[n].index !== b.layers[n].index             // skip if their indices differ
+        // skip if their indices differ
+        a.layers[n].index !== b.layers[n].index
       ) {
         return false
       }
@@ -236,8 +244,8 @@ const addImageData = (isBefore, newState) => {
 
 const sceneStateContextsEqual = (a, b) =>
   a && b &&
-  a.type == 'scene' && b.type == 'scene' &&
-  a.sceneId == b.sceneId
+  a.type === 'scene' && b.type === 'scene' &&
+  a.sceneId === b.sceneId
 
 const addSceneData = (isBefore, state) => {
   const newState = {

--- a/src/js/undo-stack.js
+++ b/src/js/undo-stack.js
@@ -265,11 +265,11 @@ const cloneState = originalState => {
   let newState = util.stringifyClone(originalState)
 
   // re-insert the references to source (HTMLCanvas)
-  if (originalState.type === 'image') {
-    for (let n = 0; n < newState.layers.length; n++) {
-      newState.layers[n].source = originalState.layers[n].source
-    }
-  }
+  // if (originalState.type === 'image') {
+  //   for (let n = 0; n < newState.layers.length; n++) {
+  //     newState.layers[n].source = originalState.layers[n].source
+  //   }
+  // }
 
   return newState
 }

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -5399,7 +5399,7 @@ const applyUndoStateForImage = async (state) => {
       )
       undoImageCache.get(layerData.source).isPreMultiplied = false
     }
-    // TODO would it be faster to use texImage2D ?
+    // TODO try directly creating texture from pixel data via texImage2D
     storyboarderSketchPane.sketchPane.replaceLayer(
       layerData.index,
       storyboarderSketchPane.sketchPane.constructor.utils.pixelsToCanvas(

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -5343,11 +5343,7 @@ const storeUndoStateForImage = (isBefore, layerIndices = null) => {
   let layers = layerIndices.map(index => {
     return {
       index,
-      // store raw pixels with premultiplied alpha
-      source: {
-        pixels: storyboarderSketchPane.sketchPane.layers[index].pixels(false),
-        premultiplied: true
-      }
+      source: storyboarderSketchPane.getUndoStateForLayer(index)
     }
   })
 
@@ -5379,24 +5375,7 @@ const applyUndoStateForImage = async (state) => {
   }
 
   for (let layerData of state.layers) {
-    let source = layerData.source
-    // un-premultiply pixels, but only once
-    if (source.premultiplied) {
-      storyboarderSketchPane.sketchPane.constructor.utils.arrayPostDivide(source.pixels)
-      // changes source, which is a reference to an to undostack state
-      source.premultiplied = false
-    }
-    // NOTE calls replaceLayer directly to avoid triggering `addToUndoStack` event
-    // TODO try directly creating texture from pixel data via texImage2D
-    storyboarderSketchPane.sketchPane.replaceLayer(
-      source.index,
-      storyboarderSketchPane.sketchPane.constructor.utils.pixelsToCanvas(
-        source.pixels,
-        storyboarderSketchPane.sketchPane.width,
-        storyboarderSketchPane.sketchPane.height
-      )
-    )
-
+    storyboarderSketchPane.applyUndoStateForLayer(layerData)
     markImageFileDirty([layerData.index])
   }
 

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -333,6 +333,33 @@ class StoryboarderSketchPane extends EventEmitter {
     }
   }
 
+  getUndoStateForLayer (index) {
+    // store raw pixels with premultiplied alpha
+    return {
+      pixels: this.sketchPane.layers[index].pixels(false),
+      premultiplied: true
+    }
+  }
+  applyUndoStateForLayer (state) {
+    let source = state.source
+    // un-premultiply pixels, but only once
+    if (source.premultiplied) {
+      this.sketchPane.constructor.utils.arrayPostDivide(source.pixels)
+      // changes source, which is a reference to an to undostack state
+      source.premultiplied = false
+    }
+    // NOTE calls replaceLayer directly to avoid triggering `addToUndoStack` event
+    // TODO try directly creating texture from pixel data via texImage2D
+    this.sketchPane.replaceLayer(
+      source.index,
+      this.sketchPane.constructor.utils.pixelsToCanvas(
+        source.pixels,
+        this.sketchPane.width,
+        this.sketchPane.height
+      )
+    )
+  }
+
   // renderCursor () {
   //   return
   //   if (this.isCursorOnDrawingArea) {


### PR DESCRIPTION
NOTE we're still putting pixels to a canvas before uploading the redo state back to the GPU. This is slow. Would be better to write the pixels directly to a WebGL texture. Something we can fix in the future.

See Also:
https://github.com/pixijs/pixi-gl-core/blob/master/src/GLTexture.js#L323
https://github.com/mrdoob/three.js/issues/386#issuecomment-1681158
PIXI v5 texture-resource