### PR TITLE
Use the typescript build of Alchemancy

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -19,6 +19,8 @@ const observeStore = require('../shared/helpers/observeStore')
 
 
 const StoryboarderSketchPane = require('./storyboarder-sketch-pane')
+const { SketchPane } = require('alchemancy')
+const SketchPaneUtil = require('alchemancy').util
 const undoStack = require('../undo-stack')
 
 const Toolbar = require('./toolbar')
@@ -2394,7 +2396,7 @@ const renderThumbnailToNewCanvas = (index, options = { forceReadFromFiles: false
 
   if (!options.forceReadFromFiles && index === currentBoard) {
     // grab from current sketchpane (in memory)
-    let canvas = storyboarderSketchPane.sketchPane.constructor.utils.pixelsToCanvas(
+    let canvas = SketchPaneUtil.pixelsToCanvas(
       storyboarderSketchPane.sketchPane.extractThumbnailPixels(size[0], size[1], [0, 1, 3]), // HACK hardcoded
       size[0],
       size[1]
@@ -4558,7 +4560,7 @@ let copyBoards = () => {
         // image: nativeImage.createFromDataURL(canvas.toDataURL()),
         // TODO could try nativeImage.createFromBuffer and pass raw pixels?
         image: nativeImage.createFromDataURL(
-          storyboarderSketchPane.sketchPane.constructor.utils.pixelsToCanvas(
+          SketchPaneUtil.pixelsToCanvas(
             storyboarderSketchPane.sketchPane.extractThumbnailPixels(
               storyboarderSketchPane.sketchPane.width,
               storyboarderSketchPane.sketchPane.height,

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -5,7 +5,8 @@ const { ipcRenderer, remote } = require('electron')
 const fs = require('fs')
 const path = require('path')
 
-const SketchPane = require('alchemancy')
+const { SketchPane } = require('alchemancy')
+const SketchPaneUtil = require('alchemancy').util
 
 const Brush = require('../sketch-pane/brush')
 const LineMileageCounter = require('./line-mileage-counter')
@@ -344,7 +345,7 @@ class StoryboarderSketchPane extends EventEmitter {
     let source = state.source
     // un-premultiply pixels, but only once
     if (source.premultiplied) {
-      this.sketchPane.constructor.utils.arrayPostDivide(source.pixels)
+      SketchPaneUtil.arrayPostDivide(source.pixels)
       // changes source, which is a reference to an to undostack state
       source.premultiplied = false
     }
@@ -352,7 +353,7 @@ class StoryboarderSketchPane extends EventEmitter {
     // TODO try directly creating texture from pixel data via texImage2D
     this.sketchPane.replaceLayer(
       source.index,
-      this.sketchPane.constructor.utils.pixelsToCanvas(
+      SketchPaneUtil.pixelsToCanvas(
         source.pixels,
         this.sketchPane.width,
         this.sketchPane.height


### PR DESCRIPTION
I don't love the way we're exporting Util (for `arrayPostDivide` and `pixelsToCanvas`) but this will work for now.