### PR TITLE
Force update from keymap 1.5.x to 1.6.x format

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -108,7 +108,7 @@ app.on('ready', async () => {
     let payload = JSON.parse(fs.readFileSync(keymapPath, { encoding: 'utf8' }))
 
     // detect Storyboarder 1.5.x keymap
-    let shouldOverwrite
+    let shouldOverwrite = false
     if (
       payload["menu:tools:pencil"] === "2" &&
       payload["menu:tools:pen"] === "3" &&

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -96,7 +96,7 @@ app.on('ready', async () => {
 
 
 
-  // try to load key map
+  // load key map
   const keymapPath = path.join(app.getPath('userData'), 'keymap.json')
   let payload = {}
   let shouldOverwrite = false

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -112,8 +112,7 @@ app.on('ready', async () => {
     console.error(err)
     dialog.showMessageBox({
       type: 'error',
-      message: `Whoops! An error ocurred while trying to read keymap.json.
-                Using default keymap instead.\n\n${err}`
+      message: `Whoops! An error ocurred while trying to read keymap.json.\nUsing default keymap instead.\n\n${err}`
     })
   }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -117,11 +117,12 @@ app.on('ready', async () => {
       payload["menu:tools:eraser"] === "6"
     ) {
       console.log('Detected a Storyboarder 1.5.x keymap. Forcing update for tools.')
-      payload["menu:tools:pencil"] = "4"
-      payload["menu:tools:pen"] = "5"
-      payload["menu:tools:brush"] = "2"
-      payload["menu:tools:note-pen"] = "6"
-      payload["menu:tools:eraser"] = "7"
+      // force defaults override
+      delete payload["menu:tools:pencil"]
+      delete payload["menu:tools:pen"]
+      delete payload["menu:tools:brush"]
+      delete payload["menu:tools:note-pen"]
+      delete payload["menu:tools:eraser"]
       shouldOverwrite = true
     }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -104,10 +104,35 @@ app.on('ready', async () => {
   // attempt to merge it in with defaults
   try {
     console.log('Reading', keymapPath)
+
+    let payload = JSON.parse(fs.readFileSync(keymapPath, { encoding: 'utf8' }))
+
+    // detect Storyboarder 1.5.x keymap
+    let shouldOverwrite
+    if (
+      payload["menu:tools:pencil"] === "2" &&
+      payload["menu:tools:pen"] === "3" &&
+      payload["menu:tools:brush"] === "4" &&
+      payload["menu:tools:note-pen"] === "5" &&
+      payload["menu:tools:eraser"] === "6"
+    ) {
+      console.log('Detected a Storyboarder 1.5.x keymap. Forcing update for tools.')
+      payload["menu:tools:pencil"] = "4"
+      payload["menu:tools:pen"] = "5"
+      payload["menu:tools:brush"] = "2"
+      payload["menu:tools:note-pen"] = "6"
+      payload["menu:tools:eraser"] = "7"
+      shouldOverwrite = true
+    }
+
     store.dispatch({
       type: 'SET_KEYMAP',
-      payload: JSON.parse(fs.readFileSync(keymapPath, { encoding: 'utf8' }))
+      payload
     })
+
+    if (shouldOverwrite) {
+      fs.writeFileSync(keymapPath, JSON.stringify(store.getState().entities.keymap, null, 2) + '\n')
+    }
   } catch (err) {
     console.error(err)
     dialog.showMessageBox({

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -94,53 +94,60 @@ app.on('ready', async () => {
   let ffmpegVersion = await exporterFfmpeg.checkVersion()
   console.log('ffmpeg version', ffmpegVersion)
 
+
+
   // try to load key map
   const keymapPath = path.join(app.getPath('userData'), 'keymap.json')
-  // ensure keymap.json exists
-  if (!fs.existsSync(keymapPath)) {
-    console.log('Creating', keymapPath)
-    fs.writeFileSync(keymapPath, JSON.stringify(defaultKeyMap, null, 2) + '\n')
-  }
-  // attempt to merge it in with defaults
-  try {
+  let payload = {}
+  let shouldOverwrite = false
+
+  if (fs.existsSync(keymapPath)) {
     console.log('Reading', keymapPath)
+    try {
+      payload = JSON.parse(fs.readFileSync(keymapPath, { encoding: 'utf8' }))
 
-    let payload = JSON.parse(fs.readFileSync(keymapPath, { encoding: 'utf8' }))
-
-    // detect Storyboarder 1.5.x keymap
-    let shouldOverwrite = false
-    if (
-      payload["menu:tools:pencil"] === "2" &&
-      payload["menu:tools:pen"] === "3" &&
-      payload["menu:tools:brush"] === "4" &&
-      payload["menu:tools:note-pen"] === "5" &&
-      payload["menu:tools:eraser"] === "6"
-    ) {
-      console.log('Detected a Storyboarder 1.5.x keymap. Forcing update for tools.')
-      // force defaults override
-      delete payload["menu:tools:pencil"]
-      delete payload["menu:tools:pen"]
-      delete payload["menu:tools:brush"]
-      delete payload["menu:tools:note-pen"]
-      delete payload["menu:tools:eraser"]
-      shouldOverwrite = true
+      // detect and migrate Storyboarder 1.5.x keymap
+      if (
+        payload["menu:tools:pencil"] === "2" &&
+        payload["menu:tools:pen"] === "3" &&
+        payload["menu:tools:brush"] === "4" &&
+        payload["menu:tools:note-pen"] === "5" &&
+        payload["menu:tools:eraser"] === "6"
+      ) {
+        console.log('Detected a Storyboarder 1.5.x keymap. Forcing update to menu:tools:*.')
+        // force defaults override
+        delete payload["menu:tools:pencil"]
+        delete payload["menu:tools:pen"]
+        delete payload["menu:tools:brush"]
+        delete payload["menu:tools:note-pen"]
+        delete payload["menu:tools:eraser"]
+        shouldOverwrite = true
+      }
+    } catch (err) {
+      // show error, but don't overwrite the keymap file
+      console.error(err)
+      dialog.showMessageBox({
+        type: 'error',
+        message: `Whoops! An error ocurred while trying to read ${keymapPath}.\nUsing default keymap instead.\n\n${err}`
+      })
     }
-
-    store.dispatch({
-      type: 'SET_KEYMAP',
-      payload
-    })
-
-    if (shouldOverwrite) {
-      fs.writeFileSync(keymapPath, JSON.stringify(store.getState().entities.keymap, null, 2) + '\n')
-    }
-  } catch (err) {
-    console.error(err)
-    dialog.showMessageBox({
-      type: 'error',
-      message: `Whoops! An error ocurred while trying to read keymap.json.\nUsing default keymap instead.\n\n${err}`
-    })
+  } else {
+    // create new keymap.json
+    shouldOverwrite = true
   }
+
+  // merge with defaults
+  store.dispatch({
+    type: 'SET_KEYMAP',
+    payload
+  })
+
+  if (shouldOverwrite) {
+    console.log('Writing', keymapPath)
+    fs.writeFileSync(keymapPath, JSON.stringify(store.getState().entities.keymap, null, 2) + '\n')
+  }
+
+
 
   if (os.platform() === 'darwin') {
     if (!isDev && !app.isInApplicationsFolder()) {


### PR DESCRIPTION
If a keymap was created by 1.5.x, it will map tools to the wrong keys.
When we open it in 1.6.x, we can detect this, and fix it automatically.

Note that if the artist does open 1.5.x again, the keys will be unexpected.

Scenarios to test:
- [x] First time Storyboarder (no keymap.json)
- [x] Upgrading from 1.5.x (keymap.json has old menu:tools:*)
- [x] Re-opening after upgrade (keymap.json has been migrated)
- [x] keymap.json with invalid JSON (should warn, use defaults, not overwrite keymap.json)

Fixes https://github.com/wonderunit/storyboarder/issues/1240