### PR TITLE
"Import and Replace" / "Paste and Replace"

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1074,8 +1074,8 @@ ipcMain.on('paste', (e, arg)=> {
   mainWindow.webContents.send('paste')
 })
 
-ipcMain.on('paste-image-only', () => {
-  mainWindow.webContents.send('paste-image-only')
+ipcMain.on('paste-replace', () => {
+  mainWindow.webContents.send('paste-replace')
 })
 
 /// TOOLS

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1070,6 +1070,10 @@ ipcMain.on('paste', (e, arg)=> {
   mainWindow.webContents.send('paste')
 })
 
+ipcMain.on('paste-image-only', () => {
+  mainWindow.webContents.send('paste-image-only')
+})
+
 /// TOOLS
 
 ipcMain.on('undo', (e, arg)=> {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -487,7 +487,7 @@ let openDialogue = () => {
   })
 }
 
-let importImagesDialogue = () => {
+let importImagesDialogue = (shouldReplace = false) => {
   dialog.showOpenDialog(
     {
       title:"Import Boards", 
@@ -526,7 +526,11 @@ let importImagesDialogue = () => {
           }
         }
         
-        mainWindow.webContents.send('insertNewBoardsWithFiles', filepathsRecursive)
+        if (shouldReplace) {
+          mainWindow.webContents.send('importImageAndReplace', filepathsRecursive)
+        } else {
+          mainWindow.webContents.send('insertNewBoardsWithFiles', filepathsRecursive)
+        }
       }
     }
   )
@@ -1129,8 +1133,8 @@ ipcMain.on('openDialogue', (e, arg) => {
   openDialogue()
 })
 
-ipcMain.on('importImagesDialogue', (e, arg)=> {
-  importImagesDialogue()
+ipcMain.on('importImagesDialogue', (e, arg) => {
+  importImagesDialogue(arg)
   mainWindow.webContents.send('importNotification', arg)
 })
 

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -170,6 +170,13 @@ AppMenu.File = () => ({
         ipcRenderer.send('importImagesDialogue')
       }
     },
+    {
+      label: 'Import and Replace Current…',
+      accelerator: keystrokeFor("menu:file:import-image-replace"),
+      click (item, focusedWindow, event) {
+        ipcRenderer.send('importImagesDialogue', true)
+      }
+    }
   ]
 })
 AppMenu.Edit = () => ({

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -171,7 +171,7 @@ AppMenu.File = () => ({
       }
     },
     {
-      label: 'Import Image and Replace Reference Layer…',
+      label: 'Import Image and Replace…',
       accelerator: keystrokeFor("menu:file:import-image-replace"),
       click (item, focusedWindow, event) {
         ipcRenderer.send('importImagesDialogue', true)
@@ -219,7 +219,7 @@ AppMenu.Edit = () => ({
       }
     },
     {
-      label: 'Paste and Replace Board Art',
+      label: 'Paste and Replace',
       accelerator: keystrokeFor('menu:edit:paste-replace'),
       click (item, focusedWindow, event) {
         ipcRenderer.send('paste-replace')

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -219,10 +219,10 @@ AppMenu.Edit = () => ({
       }
     },
     {
-      label: 'Paste and Replace Current (Image Only)',
-      accelerator: keystrokeFor('menu:edit:paste-image-only'),
+      label: 'Paste and Replace Board Art',
+      accelerator: keystrokeFor('menu:edit:paste-replace'),
       click (item, focusedWindow, event) {
-        ipcRenderer.send('paste-image-only')
+        ipcRenderer.send('paste-replace')
       }
     },
     {

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -212,6 +212,13 @@ AppMenu.Edit = () => ({
       }
     },
     {
+      label: 'Paste and Replace Current (Image Only)',
+      accelerator: keystrokeFor('menu:edit:paste-image-only'),
+      click (item, focusedWindow, event) {
+        ipcRenderer.send('paste-image-only')
+      }
+    },
+    {
       label: 'Select All',
       accelerator: keystrokeFor('menu:edit:select-all'),
       role: 'selectall'

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -171,7 +171,7 @@ AppMenu.File = () => ({
       }
     },
     {
-      label: 'Import Image To Current Reference Layer…',
+      label: 'Import Image and Replace Reference Layer…',
       accelerator: keystrokeFor("menu:file:import-image-replace"),
       click (item, focusedWindow, event) {
         ipcRenderer.send('importImagesDialogue', true)

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -167,7 +167,7 @@ AppMenu.File = () => ({
       label: 'Import Images…',
       accelerator: keystrokeFor("menu:file:import-images"),
       click (item, focusedWindow, event) {
-        ipcRenderer.send('importImagesDialogue')
+        ipcRenderer.send('importImagesDialogue', false)
       }
     },
     {

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -164,14 +164,14 @@ AppMenu.File = () => ({
       type: 'separator'
     },
     {
-      label: 'Import Images…',
+      label: 'Import Images to New Boards…',
       accelerator: keystrokeFor("menu:file:import-images"),
       click (item, focusedWindow, event) {
         ipcRenderer.send('importImagesDialogue', false)
       }
     },
     {
-      label: 'Import and Replace Current…',
+      label: 'Import Image To Current Reference Layer…',
       accelerator: keystrokeFor("menu:file:import-image-replace"),
       click (item, focusedWindow, event) {
         ipcRenderer.send('importImagesDialogue', true)

--- a/src/js/shared/helpers/defaultKeyMap.js
+++ b/src/js/shared/helpers/defaultKeyMap.js
@@ -24,6 +24,7 @@ const defaultKeyMap = {
   "menu:edit:cut": "CommandOrControl+x",
   "menu:edit:copy": "CommandOrControl+c",
   "menu:edit:paste": "CommandOrControl+v",
+  "menu:edit:paste-replace": "CommandOrControl+Shift+v",
   "menu:edit:select-all": "CommandOrControl+a",
 
   "menu:navigation:play": "Space",

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -5461,7 +5461,7 @@ let pasteBoards = async () => {
 
     } catch (err) {
       console.error(err)
-      console.log(error.stack)
+      console.log(err.stack)
       console.log(new Error().stack)
       notifications.notify({ message: `Whoops. Could not paste boards. ${err.message}`, timing: 8 })
       throw err

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -5060,9 +5060,9 @@ ipcRenderer.on('paste', () => {
   }
 })
 
-ipcRenderer.on('paste-image-only', () => {
+ipcRenderer.on('paste-replace', () => {
   notifications.notify({ message: `Pasting …` })
-  pasteImageIntoBoard()
+  pasteAndReplace()
     .then(() => {
       notifications.notify({ message: `Paste complete.` })
       sfx.positive()
@@ -5489,7 +5489,7 @@ let pasteBoards = async () => {
 }
 
 // paste to current board
-const pasteImageIntoBoard = async () => {
+const pasteAndReplace = async () => {
   if (textInputMode) return
 
   let board = boardData.boards[currentBoard]

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -5105,6 +5105,7 @@ const importImage = async imageDataURL => {
 
   // update the image
   storeUndoStateForImage(true, [layer.index])
+  layer.clear()
   layer.replace(image, false)
   storeUndoStateForImage(false, [layer.index])
   // mark new image
@@ -5120,7 +5121,7 @@ const importImage = async imageDataURL => {
   // renderThumbnailDrawer()
 
   notifications.notify({
-    message: `Image added on top of reference layer`,
+    message: `Image added as reference layer.`,
     timing: 10
   })
   sfx.positive()

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -5060,6 +5060,20 @@ ipcRenderer.on('paste', () => {
   }
 })
 
+ipcRenderer.on('paste-image-only', () => {
+  notifications.notify({ message: `Pasting …` })
+  pasteImageIntoBoard()
+    .then(() => {
+      notifications.notify({ message: `Paste complete.` })
+      sfx.positive()
+    })
+    .catch(err => {
+      console.error(err)
+      notifications.notify({ message: err.toString() })
+      sfx.error()
+    })
+})
+
 // import image from mobile server
 const importImage = async imageDataURL => {
   let board = boardData.boards[currentBoard]
@@ -5470,6 +5484,132 @@ let pasteBoards = async () => {
     notifications.notify({ message: "There's nothing in the clipboard that I can paste. Are you sure you copied it right?", timing: 8 })
     sfx.error()
     throw new Error('empty clipboard')
+  }  
+}
+
+// paste to current board
+const pasteImageIntoBoard = async () => {
+  if (textInputMode) return
+
+  let board = boardData.boards[currentBoard]
+
+  // save the current image to disk
+  await saveImageFile()
+
+  let pasted
+
+  // is paste a valid object from Storyboarder?
+  let text = clipboard.readText()
+  if (text !== '') {
+    try {
+      pasted = JSON.parse(clipboard.readText())
+      if (!pasted.boards.length || pasted.boards.length < 1) throw new Error('no boards')
+      if (!pasted.layerDataByBoardIndex.length || pasted.layerDataByBoardIndex.length < 1) throw new Error('no layer data')
+    } catch (err) {
+      console.log('could not read clipboard data')
+      console.log(err)
+    }
+  }
+
+  // paste is probably from an external source
+  if (!pasted) {
+    // can we at least grab the image?
+    let image = clipboard.readImage()
+    if (!image.isEmpty()) {
+      pasted = {
+        boards: [
+          // HACK trigger to construct a minimum board
+          {
+            layers: {
+              reference: {
+                url: null
+              }
+            }
+          }
+        ],
+        layerDataByBoardIndex: [
+          {
+            reference: image.toDataURL()
+          }
+        ]
+      }
+    } else {
+      console.log('could not read clipboard image')
+    }
+  }
+
+  if (pasted && pasted.boards && pasted.boards.length) {
+    if (pasted.boards.length > 1) {
+      throw new Error("Can't paste. Expected one image, but found multiple.")
+    }
+
+    try {
+      // store the "before" state
+      storeUndoStateForScene(true)
+      storeUndoStateForImage(true, storyboarderSketchPane.visibleLayersIndices)
+
+      // NOTE: audio is not copied
+      // NOTE: linked PSD is not copied
+
+      let imageData = pasted.layerDataByBoardIndex[0]
+
+      // scale layer images and write to layers
+      let size = [
+        storyboarderSketchPane.sketchPane.width,
+        storyboarderSketchPane.sketchPane.height
+      ]
+
+      board.layers = {}
+
+      // for every named layer
+      for (let index of storyboarderSketchPane.visibleLayersIndices) {
+        let layer = storyboarderSketchPane.sketchPane.layers[index]
+        if (imageData[layer.name]) {
+          let image = await exporterCommon.getImage(imageData[layer.name])
+          // paste the layer
+
+          // if ratio matches,
+          // don't bother drawing,
+          // just return original image data
+          if (
+            image.width === size[0] &&
+            image.height === size[1]
+          ) {
+            // full size
+            // console.log('\tpasting full size', layer.name)
+            storyboarderSketchPane.sketchPane.replaceLayer(index, image)
+            markImageFileDirty([index])
+          } else {
+            // resized
+            // console.log('\tpasting resized', layer.name)
+            let context = createSizedContext(size)
+            let canvas = context.canvas
+            context.drawImage(image, ...util.fitToDst(canvas, image).map(Math.round))
+            storyboarderSketchPane.sketchPane.replaceLayer(index, canvas)
+            markImageFileDirty([index])
+          }
+        } else {
+          // clear the layer
+          // console.log('\tclearing', layer.name)
+          storyboarderSketchPane.clearLayer(index)
+        }
+      }
+
+      storeUndoStateForScene()
+      storeUndoStateForImage(false, storyboarderSketchPane.visibleLayersIndices)
+
+      markBoardFileDirty()
+      renderThumbnailDrawer()
+
+      console.log('paste complete')
+    } catch (err) {
+      console.error(err)
+      console.log(err.stack)
+      console.log(new Error().stack)
+      throw new Error(`Whoops. Could not paste image. ${err.message}`)
+    }
+  } else {
+    throw new Error("There's nothing in the clipboard that I can paste. Are you sure you copied it correctly?")
   }  
 }
 

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -6447,6 +6447,24 @@ ipcRenderer.on('importImage', (event, fileData) => {
   // console.log('mobile image import fileData:', fileData)
   importImage(fileData)
 })
+ipcRenderer.on('importImageAndReplace', (sender, filepathsRecursive) => {
+  let filepath = filepathsRecursive[0]
+  let type = path.extname(filepath).slice(1)
+
+  if (type === 'psd') {
+    notifications.notify({ message: 'Sorry, PSD is not supported for this command yet.' })
+    sfx.error()
+    return
+  }
+
+  let data = fs.readFileSync(filepath).toString('base64')
+  let fileData = `data:image/${type};base64,${data}`
+
+  importImage(fileData).catch(err => {
+    notifications.notify({ message: err.toString() })
+    sfx.error()
+  })
+})
 
 ipcRenderer.on('toggleGuide', (event, arg) => {
   console.log('toggleGuide', arg)
@@ -6588,7 +6606,7 @@ ipcRenderer.on('importFromWorksheet', (event, args) => {
   importFromWorksheet(args)
 })
 
-ipcRenderer.on('importNotification', (event, args) => {
+ipcRenderer.on('importNotification', () => {
   let hostname = os.hostname()
   let that = this
   dns.lookup(hostname, function (err, add, fam) {


### PR DESCRIPTION
Adds two new commands

**File > Import Image to Current Reference Layer …**
- Selected PNG/JPG will replace reference layer of _current_ board, leaving metadata in tact
- PSD is not supported for this feature

**Edit >Paste and Replace Current (Image Only) …**
- Pasting layers (from another board) replaces all layers
- Pasting a single image (from system clipboard) replaces current reference layer
- Pasting a file (from system clipboard) replaces current reference layer)
- Pasting multiple files will just select the first one in the list and use it to replace current reference layer
- Pasting a PSD (from system clipboard) will replace current reference layer with flattened contents (test: is this full resolution? or from a small-resolution psd preview?)
- audio is not copied over
- linked psd is not copied over

Tasks
- [x] Re-word the menu labels
- [x] Add default key bindings
- [x] Re-test that layer files and data are written correctly (test multi, single, then multi again, then single again).

Closes #977 