### PR TITLE
Improvements for WebGL performance

### DIFF
--- a/src/css/context-menu.css
+++ b/src/css/context-menu.css
@@ -1,6 +1,12 @@
 .popup-container {
   position: absolute;
 }
+.popup-container {
+  visibility: hidden;
+}
+.popup-container.is-visible {
+  visibility: visible;
+}
 
 /**/
 

--- a/src/js/window/color-picker.js
+++ b/src/js/window/color-picker.js
@@ -171,6 +171,7 @@ class ColorPicker extends EventEmitter {
   }
   
   fadeIn () {
+    this.el.classList.add('is-visible')
     this.innerEl.classList.add('appear-anim')
 
     tooltips.closeAll()
@@ -179,6 +180,7 @@ class ColorPicker extends EventEmitter {
 
   fadeOut () {
     this.innerEl.classList.remove('appear-anim')
+    this.el.classList.remove('is-visible')
     tooltips.setIgnore(document.querySelector('#toolbar-current-color'), false)
   }
   

--- a/src/js/window/context-menu.js
+++ b/src/js/window/context-menu.js
@@ -72,11 +72,13 @@ class ContextMenu extends EventEmitter {
   
   fadeIn () {
     this.emit('shown')
+    this.el.classList.add('is-visible')
     this.innerEl.classList.add('appear-anim')
   }
 
   fadeOut () {
     this.innerEl.classList.remove('appear-anim')
+    this.el.classList.remove('is-visible')
   }
   
   hasChild (child) {

--- a/src/js/window/context-menu.js
+++ b/src/js/window/context-menu.js
@@ -17,7 +17,7 @@ class ContextMenu extends EventEmitter {
   }
 
   template () {
-    return `<div class="context-menu-container">
+    return `<div class="context-menu-container popup-container">
       <div id="context-menu" class="bottom-nub">
         <div class="item" data-action="add">Add New <div class="key-command">${acceleratorAsHtml('n', { animated: false }) }</div></div>
         <div class="item" data-action="duplicate">Duplicate <div class="key-command">${acceleratorAsHtml('d', { animated: false })}</div></div>

--- a/src/js/window/pomodoro-timer-view.js
+++ b/src/js/window/pomodoro-timer-view.js
@@ -268,6 +268,7 @@ class PomodorTimerView extends EventEmitter {
   }
 
   fadeIn () {
+    this.el.classList.add('is-visible')
     this.innerEl.classList.add('appear-anim')
 
     tooltips.closeAll()
@@ -276,6 +277,7 @@ class PomodorTimerView extends EventEmitter {
 
   fadeOut () {
     this.innerEl.classList.remove('appear-anim')
+    this.el.classList.remove('is-visible')
     tooltips.setIgnore(document.querySelector('#toolbar-pomodoro-rest'), false)
   }
 


### PR DESCRIPTION
Overlapping `div` elements were causing WebGL slow-downs. This change sets `visiblity: false` on them when not in use.