### PR TITLE
AudioFileControlView can be in "failed" mode

### DIFF
--- a/src/js/window/audio-file-control-view.js
+++ b/src/js/window/audio-file-control-view.js
@@ -2,7 +2,7 @@ class AudioFileControlView {
   constructor ({ onRequestFile, onSelectFile, onSelectFileCancel, onClear, onStartRecord, onStopRecord, onAudioComplete, onCounterTick, onNotify }) {
     this.state = {
       boardAudio: undefined,
-      mode: 'initializing', // initializing, stopped, countdown, recording, finalizing
+      mode: 'initializing', // initializing, stopped, countdown, recording, finalizing, failed
       counter: undefined,
 
       lastAudioData: undefined,
@@ -61,6 +61,7 @@ class AudioFileControlView {
       console.error(err)
       this.onNotify({ message: 'An error prevented the audio recorder from initializing' })
       this.onNotify({ message: err.toString() })
+      this.setState({ mode: 'failed' })
     })
   }
 
@@ -129,6 +130,14 @@ class AudioFileControlView {
       boardAudio,
       mode: 'recording'
     })
+  }
+
+  isIdle () {
+    return (
+      this.state.mode === 'initializing' ||
+      this.state.mode === 'stopped' ||
+      this.state.mode === 'failed'
+    )
   }
 
   isCountingDownOrRecording () {
@@ -233,6 +242,11 @@ class AudioFileControlView {
     //   return
     // }
 
+    if (this.state.mode === 'failed') {
+      recordButton.querySelector('.flatbutton').style.pointerEvents = 'none'
+      recordButton.style.opacity = 0.5
+      recordButton.style.cursor = 'not-allowed'
+    }
 
     audiofileButton.style.display = 'block'
     audiofileClearBtnEl.style.display = 'block'

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1612,9 +1612,10 @@ const loadBoardUI = async () => {
     getAudioFilePath: (filename) => path.join(boardPath, 'images', filename)
   })
   audioFileControlView = new AudioFileControlView({
+    // onSelectFile = via drop
     onSelectFile: async function (filepath) {
-      if (audioFileControlView.state.mode !== 'stopped') {
-        notifications.notify({ message: `Can't add an audio file while ${audioFileControlView.state.mode}.`, timing: 5 })
+      if ( ! audioFileControlView.isIdle() ) {
+        notifications.notify({ message: `Can’t add an audio file while recorder is active. Recorder mode is: ${audioFileControlView.state.mode}.`, timing: 5 })
         return
       }
 
@@ -1665,11 +1666,12 @@ const loadBoardUI = async () => {
     onSelectFileCancel: function () {
       // NOOP
     },
+    // onRequestFile = via dialog
     onRequestFile: function (event) {
       if (event) event.preventDefault()
 
-      if (audioFileControlView.state.mode !== 'stopped') {
-        notifications.notify({ message: `Can't add an audio file while ${audioFileControlView.state.mode}.`, timing: 5 })
+      if ( ! audioFileControlView.isIdle() ) {
+        notifications.notify({ message: `Can’t add an audio file while recorder is active. Recorder mode is: ${audioFileControlView.state.mode}.`, timing: 5 })
         return
       }
 


### PR DESCRIPTION
"failed" means the recorder could not initialize

users can still add audio via the file selector while "idle" (which in this case means "initializing", "stopped", or "failed")

fixes #969