### PR TITLE
Straight Line Drawing

### DIFF
--- a/src/js/shared/helpers/defaultKeyMap.js
+++ b/src/js/shared/helpers/defaultKeyMap.js
@@ -9,6 +9,8 @@ const defaultKeyMap = {
   "drawing:quick-erase-modifier": "Alt",
   "drawing:exit-current-mode": "Escape",
   "drawing:pan-mode": "Shift",
+  "drawing:straight-line": "Shift",
+  "drawing:straight-line-snap": "Space",
 
   "menu:file:open": "CommandOrControl+o",
   "menu:file:save": "CommandOrControl+s",

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -4593,9 +4593,11 @@ window.onkeydown = (e)=> {
       audioPlayback.stopAllSounds()
     }
 
-    if (isCommandPressed('menu:navigation:play')) {
-      e.preventDefault()
-      togglePlayback()
+    if (!storyboarderSketchPane.getIsDrawingOrStabilizing()) {
+      if (isCommandPressed('menu:navigation:play')) {
+        e.preventDefault()
+        togglePlayback()
+      }
     }
   }
 

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -320,8 +320,10 @@ class StoryboarderSketchPane extends EventEmitter {
       })
     }
 
-    if (this.isCommandPressed('drawing:straight-line')) {
-      this.sketchPane.setIsStraightLine(true)
+    if (this.getIsDrawingOrStabilizing()) {
+      if (this.isCommandPressed('drawing:straight-line')) {
+        this.sketchPane.setIsStraightLine(true)
+      }
       if (this.isCommandPressed('drawing:straight-line-snap')) {
         this.sketchPane.setShouldSnap(true)
       }
@@ -345,9 +347,9 @@ class StoryboarderSketchPane extends EventEmitter {
 
     if (!this.isCommandPressed('drawing:straight-line')) {
       // this.sketchPane.setIsStraightLine(false)
-      if (!this.isCommandPressed('drawing:straight-line-snap')) {
-        this.sketchPane.setShouldSnap(false)
-      }
+    }
+    if (!this.isCommandPressed('drawing:straight-line-snap')) {
+      this.sketchPane.setShouldSnap(false)
     }
   }
 

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -319,6 +319,13 @@ class StoryboarderSketchPane extends EventEmitter {
         meta: { scope: 'local' }
       })
     }
+
+    if (this.isCommandPressed('drawing:straight-line')) {
+      this.sketchPane.setIsStraightLine(true)
+      if (this.isCommandPressed('drawing:straight-line-snap')) {
+        this.sketchPane.setShouldSnap(true)
+      }
+    }
   }
 
   onKeyUp (e) {
@@ -333,6 +340,13 @@ class StoryboarderSketchPane extends EventEmitter {
       // play a sound if it worked
       if (this.store.getState().toolbar.mode === 'drawing') {
         sfx.playEffect('metal')
+      }
+    }
+
+    if (!this.isCommandPressed('drawing:straight-line')) {
+      // this.sketchPane.setIsStraightLine(false)
+      if (!this.isCommandPressed('drawing:straight-line-snap')) {
+        this.sketchPane.setShouldSnap(false)
       }
     }
   }


### PR DESCRIPTION
Enter straight line mode automatically if idle for more than 500 msecs.
Hold <kbd>Shift</kbd> to switch immediately to straight line mode while drawing.
Additionally, hold <kbd>Space</kbd> while in straight line mode to snap line to 45 degree angles.
Once straight line mode is enabled, it can't be turned off until the line is completed (e.g. mouse or pen up).

Because <kbd>Shift</kbd> is already mapped to pan, <kbd>Shift</kbd> for straight line only works if you press it _after_ you’ve started drawing a line.
<kbd>Space</kbd> is also mapped to Play/Pause, but only when not currently drawing.
