### PR TITLE
Fix 'Import Image(s)...' menu items for Linux and Windows

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -508,7 +508,6 @@ let importImagesDialogue = (shouldReplace = false) => {
       ],
       properties: [
         "openFile",
-        "openDirectory",
         "multiSelections"
       ]
     },


### PR DESCRIPTION
Fix for bug #1312 

Removes the `openDirectory` property in the `dialog.showOpenDialog` options object for `importImagesDialogue`. This will prevent a user's directory or images from being inaccessible when they select the `Import Images to New Boards...` or `Import Image and Replace...` options from the `File` menu on Linux or Windows.

I took this approach because:
1. The `openFile` and `openDirectory` properties seem incompatible; `openDirectory` will override `openFile` in Linux and Windows, making it so that users can't select individual files, only directories. In Windows the files are hidden entirely.
2. When in Linux, the image extension filters in the `dialog.showOpenDialog` options object aren't compatible with `openDirectory`. Electron itself is checking for these extensions against directories instead of files, making them inaccessible to the user. For example with the jpg filter applied, Documents.jpg will be accessible to a Linux user, but not Documents.
3. Since the filters don't seem to apply to directory contents, this creates a bug since their contents won't be properly filtered. If the folder contains an incompatible file format (e.g. gif), the import will crash.

The downside to this is fix is that users will lose the ability to import images by choosing a directory. So I thought - if the idea is viable - that it might be worth it to add a new `Import Folder Contents to New Boards...` menu option that will handle folder imports. That way there won't be any conflicts between the `openFile` and `openDirectory` properties, and new logic could be added to the `dialog.showOpenDialog` callback that will check if directory contents are an image or not. 