### PR TITLE
Shot Generator: calculate displayName property of scene object on some scene changes

### DIFF
--- a/src/js/shared/reducers/shot-generator.js
+++ b/src/js/shared/reducers/shot-generator.js
@@ -182,10 +182,14 @@ const withDisplayNames = sceneObjects => {
       : 1
 
     let number = countByType[sceneObject.type]
+    let displayName = capitalize(`${sceneObject.type} ${number}`)
 
-    sceneObjects[id] = {
-      ...sceneObjects[id],
-      displayName: capitalize(`${sceneObject.type} ${number}`)
+    if (sceneObjects[id].displayName !== displayName) {
+      // mutate
+      sceneObjects[id] = {
+        ...sceneObjects[id],
+        displayName
+      }
     }
   }
 

--- a/src/js/shared/reducers/shot-generator.js
+++ b/src/js/shared/reducers/shot-generator.js
@@ -701,6 +701,21 @@ module.exports = {
           checkForSkeletonChanges(state, draft, action)
           return
 
+        case 'DUPLICATE_OBJECT':
+          let source = draft.sceneObjects[action.payload.id]
+          if (source) {
+            let object = {
+              ...source,
+              name: source.name == null ? null : source.name + ' copy',
+              x: source.x + (Math.random() * 2 - 1),
+              y: source.y + (Math.random() * 2 - 1),
+              z: source.z,
+              id: action.payload.destinationId
+            }
+            draft.sceneObjects[action.payload.destinationId] = object
+          }
+          return
+
         case 'UPDATE_CHARACTER_SKELETON':
           draft.sceneObjects[action.payload.id].skeleton = draft.sceneObjects[action.payload.id].skeleton || {}
           draft.sceneObjects[action.payload.id].skeleton[action.payload.name] = {
@@ -844,21 +859,6 @@ module.exports = {
           }
           if (action.payload.tiltDirectional != null) {
             draft.world.directional.tilt = action.payload.tiltDirectional
-          }
-          return
-
-        case 'DUPLICATE_OBJECT':
-          let source = draft.sceneObjects[action.payload.id]
-          if (source) {
-            let object = {
-              ...source,
-              name: source.name == null ? null : source.name + ' copy',
-              x: source.x + (Math.random() * 2 - 1),
-              y: source.y + (Math.random() * 2 - 1),
-              z: source.z,
-              id: action.payload.destinationId
-            }
-            draft.sceneObjects[action.payload.destinationId] = object
           }
           return
 

--- a/src/js/shared/reducers/shot-generator.js
+++ b/src/js/shared/reducers/shot-generator.js
@@ -713,6 +713,7 @@ module.exports = {
               id: action.payload.destinationId
             }
             draft.sceneObjects[action.payload.destinationId] = object
+            draft.sceneObjects = withDisplayNames(draft.sceneObjects)
           }
           return
 

--- a/src/js/shot-generator/Editor.js
+++ b/src/js/shot-generator/Editor.js
@@ -829,11 +829,6 @@ const ListItem = ({ index, style, isScrolling, data }) => {
     ? items[0]
     : items[index]
 
-  // HACK this should be based directly on state.sceneObjects, or cached in the sceneObject data
-  const number = items.filter(o => o.type === sceneObject.type).indexOf(sceneObject) + 1
-  const capitalize = string => string.charAt(0).toUpperCase() + string.slice(1)
-  const calculatedName = capitalize(`${sceneObject.type} ${number}`)
-
   return h(
     isWorld
     ? [
@@ -849,7 +844,6 @@ const ListItem = ({ index, style, isScrolling, data }) => {
           index,
           style,
           sceneObject,
-          calculatedName,
           isSelected: sceneObject.id === selection,
           isActive: sceneObject.type === 'camera' && sceneObject.id === activeCamera,
           allowDelete: (
@@ -875,8 +869,7 @@ const Inspector = ({
   updateCharacterSkeleton,
   updateWorld,
   updateWorldRoom,
-  updateWorldEnvironment,
-  calculatedName
+  updateWorldEnvironment
 }) => {
   const { scene } = useContext(SceneContext)
 
@@ -917,9 +910,7 @@ const Inspector = ({
             machineState,
             transition,
             selectBone,
-            updateCharacterSkeleton,
-
-            calculatedName
+            updateCharacterSkeleton
           }
         ]
       : [
@@ -1281,15 +1272,6 @@ const ElementsPanel = connect(
     let kind = sceneObjects[selection] && sceneObjects[selection].type
     let data = sceneObjects[selection]
 
-    // HACK this should be based directly on state.sceneObjects, or cached in the sceneObject data
-    let calculatedName
-    let sceneObject = sceneObjects[selection]
-    if (sceneObject) {
-      const number = Object.values(sceneObjects).filter(o => o.type === sceneObject.type).indexOf(sceneObject) + 1
-      const capitalize = string => string.charAt(0).toUpperCase() + string.slice(1)
-      calculatedName = capitalize(`${sceneObject.type} ${number}`)
-    }
-
     return React.createElement(
       'div', { style: { flex: 1, display: 'flex', flexDirection: 'column' }},
         React.createElement(
@@ -1315,9 +1297,7 @@ const ElementsPanel = connect(
 
             updateWorld,
             updateWorldRoom,
-            updateWorldEnvironment,
-
-            calculatedName
+            updateWorldEnvironment
           }]
         )
       )
@@ -1639,7 +1619,7 @@ const MORPH_TARGET_LABELS = {
   'ectomorphic': 'ecto',
   'endomorphic': 'obese',
 }
-const InspectedElement = ({ sceneObject, models, updateObject, selectedBone, machineState, transition, selectBone, updateCharacterSkeleton, calculatedName }) => {
+const InspectedElement = ({ sceneObject, models, updateObject, selectedBone, machineState, transition, selectBone, updateCharacterSkeleton }) => {
   const createOnSetValue = (id, name, transform = value => value) => value => updateObject(id, { [name]: transform(value) })
 
   let positionSliders = [
@@ -1691,7 +1671,7 @@ const InspectedElement = ({ sceneObject, models, updateObject, selectedBone, mac
           key: sceneObject.id,
           label: sceneObject.name != null
             ? sceneObject.name
-            : calculatedName,
+            : sceneObject.displayName,
           onFocus,
           onBlur,
           setLabel: name => {
@@ -2053,7 +2033,7 @@ const BoneEditor = ({ sceneObject, bone, updateCharacterSkeleton }) => {
 }
 
 const ELEMENT_HEIGHT = 40
-const Element = React.memo(({ index, style, sceneObject, isSelected, isActive, selectObject, updateObject, deleteObject, setActiveCamera, machineState, transition, allowDelete, calculatedName }) => {
+const Element = React.memo(({ index, style, sceneObject, isSelected, isActive, selectObject, updateObject, deleteObject, setActiveCamera, machineState, transition, allowDelete }) => {
   const onClick = preventDefault(event => {
     selectObject(sceneObject.id)
 
@@ -2102,7 +2082,7 @@ const Element = React.memo(({ index, style, sceneObject, isSelected, isActive, s
                 ['span.name', sceneObject.name]
               ]
             : [
-                ['span.id', calculatedName]
+                ['span.id', sceneObject.displayName]
               ]
           ),
         ],
@@ -2769,19 +2749,10 @@ const ClosestObjectInspector = ({ camera, sceneObjects, characters }) => {
 
         let [distFeet, distInches] = metersAsFeetAndInches(closest.distance)
 
-        // HACK this should be based directly on state.sceneObjects,
-        //      or cached in the sceneObject data
-        let calculatedName
         let sceneObject = closest.object ? sceneObjects[closest.object.userData.id] : undefined
-        if (sceneObject) {
-          // TODO DRY
-          const number = Object.values(sceneObjects).filter(o => o.type === sceneObject.type).indexOf(sceneObject) + 1
-          const capitalize = string => string.charAt(0).toUpperCase() + string.slice(1)
-          calculatedName = sceneObject.name || capitalize(`${sceneObject.type} ${number}`)
-        }
 
-        setResult(closest.object
-          ? `Distance to ${calculatedName}: ${feetAndInchesAsString(distFeet, distInches)} (${parseFloat(Math.round(closest.distance * 100) / 100).toFixed(2)}m)`
+        setResult(sceneObject
+          ? `Distance to ${sceneObject.name || sceneObject.displayName}: ${feetAndInchesAsString(distFeet, distInches)} (${parseFloat(Math.round(closest.distance * 100) / 100).toFixed(2)}m)`
           : '')
 
       } catch (err) {

--- a/test/shot-generator/reducers.test.main.js
+++ b/test/shot-generator/reducers.test.main.js
@@ -28,7 +28,7 @@ describe('reducer', () => {
       let state = store.getState()
 
       for (let id in state.sceneObjects) {
-        assert(state.sceneObjects[id] != null)
+        assert(state.sceneObjects[id].displayName != null)
       }
 
       assert.equal(state.sceneObjects['6BC46A44-7965-43B5-B290-E3D2B9D15EEE'].displayName, 'Camera 1')

--- a/test/shot-generator/reducers.test.main.js
+++ b/test/shot-generator/reducers.test.main.js
@@ -1,0 +1,39 @@
+/* global describe it  */
+
+// npx floss -p test/shot-generator/reducers.test.main.js
+
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+
+const { createStore } = require('redux')
+
+const r = require('../../src/js/shared/reducers/shot-generator')
+
+const store = createStore(r.reducer)
+
+describe('reducer', () => {
+  describe('sceneObjects', () => {
+    it('has a displayName when name is undefined', () => {
+      let state = store.getState()
+      assert.equal(state.sceneObjects['6BC46A44-7965-43B5-B290-E3D2B9D15EEE'].displayName, 'Camera 1')
+    })
+
+    it('updates displayName of scene objects when a file is loaded', () => {
+      let json = fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'shot-generator', 'shot-generator.storyboarder'))
+      let data = JSON.parse(json)
+      let payload = data.boards[0].sts.data
+
+      store.dispatch({ type: 'LOAD_SCENE', payload })
+      let state = store.getState()
+
+      for (let id in state.sceneObjects) {
+        assert(state.sceneObjects[id] != null)
+      }
+
+      assert.equal(state.sceneObjects['6BC46A44-7965-43B5-B290-E3D2B9D15EEE'].displayName, 'Camera 1')
+    })
+  })
+})
+
+


### PR DESCRIPTION
Re-calculate `displayName` property of every scene object on the following actions:

- LOAD_SCENE
- CREATE_OBJECT
- DELETE_OBJECT
- DUPLICATE_OBJECT