### PR TITLE
Shot Generator: remember window position and size during a session

### DIFF
--- a/src/js/windows/shot-generator/main.js
+++ b/src/js/windows/shot-generator/main.js
@@ -8,6 +8,12 @@ process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = true
 
 let win
 
+let memento = {
+  x: undefined,
+  y: undefined,
+  width: 1500,
+  height: 1080
+}
 
 const reveal = onComplete => {
   win.show()
@@ -21,13 +27,17 @@ const show = (onComplete) => {
     return
   }
 
+  let { x, y, width, height } = memento
+
   win = new BrowserWindow({
-    width: 1500,
-    height: 1080,
     minWidth: isDev ? undefined : 1200,
     minHeight: isDev ? undefined : 800,
-    // x: 0,
-    // y: 0,
+
+    x,
+    y,
+    width,
+    height,
+
     show: false,
     center: true,
     frame: true,

--- a/src/js/windows/shot-generator/main.js
+++ b/src/js/windows/shot-generator/main.js
@@ -77,6 +77,9 @@ const show = (onComplete) => {
     }
   })
 
+  win.on('resize', () => memento = win.getBounds())
+  win.on('move', () => memento = win.getBounds())
+
   win.once('closed', () => {
     win = null
   })

--- a/src/js/windows/shot-generator/main.js
+++ b/src/js/windows/shot-generator/main.js
@@ -4,9 +4,10 @@ const isDev = require('electron-is-dev')
 const path = require('path')
 const url = require('url')
 
+process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = true
+
 let win
 
-process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = true
 
 const reveal = onComplete => {
   win.show()


### PR DESCRIPTION
This only works during a session. Once you close the app, the window position and size are forgotten.

I'll add some code in the future to persist the values to disk, and load them back for new sessions.