### PR TITLE
Shot Generator: in BonesHelper, cache clone per model type

### DIFF
--- a/src/js/shot-generator/BonesHelper.js
+++ b/src/js/shot-generator/BonesHelper.js
@@ -260,16 +260,13 @@ function BonesHelper( object, object3D, { boneLengthScale = 1, cacheKey } ) {
     object3D.children[0].children.find(child => child instanceof THREE.SkinnedMesh)
   
 
-  console.time('new BonesHelper')
-  console.log('new BonesHelper', 'cacheKey:', cacheKey)
+  // console.log('new BonesHelper', 'cacheKey:', cacheKey)
   let skeleton_clone
   if (!cache[cacheKey]) {
     console.log('adding to cache', cacheKey)
     cache[cacheKey] = cloneSkinned( object3D )
   }
   skeleton_clone = cache[cacheKey]
-  console.log('\n\n\n\n\n\n')
-  console.timeEnd('new BonesHelper')
 
   let zeroedSkinnedMesh = skeleton_clone.children.find(child => child instanceof THREE.SkinnedMesh) ||
     skeleton_clone.children[0].children.find(child => child instanceof THREE.SkinnedMesh)

--- a/src/js/shot-generator/BonesHelper.js
+++ b/src/js/shot-generator/BonesHelper.js
@@ -251,14 +251,25 @@ function filter_array(test_array) {
     return result
 }
 
-function BonesHelper( object, object3D, { boneLengthScale = 1 } ) {
+const cache = {}
+
+function BonesHelper( object, object3D, { boneLengthScale = 1, cacheKey } ) {
   Object3D.call( this )
   //ModelLoader.isCustomModel(model)
   let sknMesh = object3D.children.find(child => child instanceof THREE.SkinnedMesh) ||
     object3D.children[0].children.find(child => child instanceof THREE.SkinnedMesh)
   
 
-  let skeleton_clone = cloneSkinned( object3D )
+  console.time('new BonesHelper')
+  console.log('new BonesHelper', 'cacheKey:', cacheKey)
+  let skeleton_clone
+  if (!cache[cacheKey]) {
+    console.log('adding to cache', cacheKey)
+    cache[cacheKey] = cloneSkinned( object3D )
+  }
+  skeleton_clone = cache[cacheKey]
+  console.log('\n\n\n\n\n\n')
+  console.timeEnd('new BonesHelper')
 
   let zeroedSkinnedMesh = skeleton_clone.children.find(child => child instanceof THREE.SkinnedMesh) ||
     skeleton_clone.children[0].children.find(child => child instanceof THREE.SkinnedMesh)

--- a/src/js/shot-generator/Character.js
+++ b/src/js/shot-generator/Character.js
@@ -231,7 +231,7 @@ const Character = React.memo(({
       
       object.current.userData.mesh = mesh
       scene.add(object.current)
-      let bonesHelper = new BonesHelper( skeleton.bones[0].parent, object.current, { boneLengthScale } )
+      let bonesHelper = new BonesHelper( skeleton.bones[0].parent, object.current, { boneLengthScale, cacheKey: props.model } )
       mesh.layers.disable(0)
       mesh.layers.enable(1)
       mesh.layers.disable(2)

--- a/src/js/shot-generator/Character.js
+++ b/src/js/shot-generator/Character.js
@@ -216,22 +216,24 @@ const Character = React.memo(({
       const { mesh, skeleton, armatures, originalHeight, boneLengthScale, parentRotation, parentPosition } = characterFactory(modelData)
 
       object.current = new THREE.Object3D()
+      object.current.add(...armatures)
+      object.current.add(mesh)
+      let bonesHelper = new BonesHelper( skeleton.bones[0].parent, object.current, { boneLengthScale, cacheKey: props.model } )
+
       object.current.userData.id = id
       object.current.userData.type = type
       object.current.userData.originalHeight = originalHeight
 
       // FIXME get current .models from getState()
       object.current.userData.modelSettings = initialState.models[props.model] || {}
-      
-      object.current.add(...armatures)
-      object.current.add(mesh)
-      
+
       object.current.orthoIcon = new IconSprites( type, props.name?props.name:props.displayName, object.current )
-      scene.add(object.current.orthoIcon)
       
       object.current.userData.mesh = mesh
+
       scene.add(object.current)
-      let bonesHelper = new BonesHelper( skeleton.bones[0].parent, object.current, { boneLengthScale, cacheKey: props.model } )
+      scene.add(object.current.orthoIcon)
+
       mesh.layers.disable(0)
       mesh.layers.enable(1)
       mesh.layers.disable(2)


### PR DESCRIPTION
BonesHelper generates a clone of the character object (skinned mesh + armature), which is expensive. This PR caches that clone per model type so it can be re-used.

Related to #1602