### PR TITLE
Shot Generator 2.0: save shot generator data to .sg instead of .sts

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -3402,10 +3402,10 @@ let gotoBoard = (boardNumber, shouldPreserveSelections = false) => {
     //   StsSidebar.reset(board.sts)
     // }
 
-    guides && guides.setPerspectiveParams({
-      cameraParams: board.sts && board.sts.camera,
-      rotation: 0
-    })
+    // guides && guides.setPerspectiveParams({
+    //   cameraParams: board.sts && board.sts.camera,
+    //   rotation: 0
+    // })
 
     ipcRenderer.send('analyticsEvent', 'Board', 'go to board', null, currentBoard)
 

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -6958,8 +6958,8 @@ const saveToBoardFromShotGenerator = async ({ uid, data, images }) => {
         opacity: 1.0
       },
     },
-    // TODO should we use a different key than .sts? (like .shotgen? or .sg?)
-    sts: {
+    // shot generator
+    sg: {
       version: pkg.version,
       data
     }

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1900,17 +1900,20 @@ const loadBoardUI = async () => {
 
 
 
-  document.querySelector("#shot-generator-container .flatbutton").addEventListener('click', event => {
-    event.preventDefault()
-    ipcRenderer.send('shot-generator:open', {
-      storyboarderFilePath: boardFilename,
-      boardData: {
-        version: boardData.version,
-        aspectRatio: boardData.aspectRatio
-      },
-      board: boardData.boards[currentBoard]
+  // Open Shot Generator button
+  document
+    .querySelector("#shot-generator-container .flatbutton")
+    .addEventListener('click', event => {
+      event.preventDefault()
+      ipcRenderer.send('shot-generator:open', {
+        storyboarderFilePath: boardFilename,
+        boardData: {
+          version: boardData.version,
+          aspectRatio: boardData.aspectRatio
+        },
+        board: boardData.boards[currentBoard]
+      })
     })
-  })
 
 
 

--- a/src/js/windows/shot-generator/window.js
+++ b/src/js/windows/shot-generator/window.js
@@ -63,8 +63,7 @@ const store = configureStore({
 
 
 ipcRenderer.on('loadBoard', (event, { storyboarderFilePath, boardData, board }) => {
-  // TODO for backwards compatibility, use board.shotgen or board.sg instead?
-  let shot = board.sts
+  let shot = board.sg
 
   store.dispatch({ type: 'SET_META_STORYBOARDER_FILE_PATH', payload: storyboarderFilePath })
 


### PR DESCRIPTION
saves shots to `board.sg`
loads shots from `board.sg`
old data in `board.sts` is ignored