### PR TITLE
Handle missing linked PSD files

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -267,11 +267,11 @@ const load = async (event, args) => {
 
     migrateScene()
 
-    logToView({ type: 'progress', message: 'Rendering User Interface' })
     await loadBoardUI()
 
     ///////////////////////////////////////////////////////////////
     // was: updateBoardUI
+    logToView({ type: 'progress', message: 'Rendering User Interface' })
     document.querySelector('#canvas-caption').style.display = 'none'
     renderViewMode()
     await ensureBoardExists()

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -705,6 +705,7 @@ const verifyScene = async () => {
       if (!fs.existsSync(path.join(boardPath, 'images', board.link))) {
       let message = `[WARNING] This scene is missing the linked file ${board.link}. ` +
                     `It will be unlinked.`
+        log.warn(message)
         notifications.notify({ message, timing: 60 })
         delete board.link
         markBoardFileDirty()

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -696,6 +696,7 @@ const verifyScene = async () => {
                                     'You should not see this warning again for this scene.', timing: 60 })
   }
 
+
   //
   //
   // PSD: notify about any missing PSD file, and unlink
@@ -712,6 +713,13 @@ const verifyScene = async () => {
       }
     }
   }
+  // setup LinkedFileManager
+  if (linkedFileManager) { linkedFileManager.dispose() }
+  linkedFileManager = new LinkedFileManager({ storyboarderFilePath: boardFilename })
+  boardData.boards
+    .filter(b => b.link)
+    .forEach(b => linkedFileManager.addBoard(b, { skipTimestamp: true }))
+
 
   let boardsWithMissingPosterFrames = []
   for (let board of boardData.boards) {
@@ -1900,11 +1908,6 @@ const loadBoardUI = async () => {
       notifications.notify(...rest)
     }
   })
-
-  linkedFileManager = new LinkedFileManager({ storyboarderFilePath: boardFilename })
-  boardData.boards
-    .filter(b => b.link)
-    .forEach(b => linkedFileManager.addBoard(b, { skipTimestamp: true }))
 
   menu.setMenu()
   // HACK initialize the menu to match the value in preferences

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -267,10 +267,18 @@ const load = async (event, args) => {
 
     migrateScene()
 
+    logToView({ type: 'progress', message: 'Rendering User Interface' })
     await loadBoardUI()
-    await updateBoardUI()
+
+    ///////////////////////////////////////////////////////////////
+    // was: updateBoardUI
+    document.querySelector('#canvas-caption').style.display = 'none'
+    renderViewMode()
+    await ensureBoardExists()
+    ///////////////////////////////////////////////////////////////
 
     await verifyScene()
+    await renderScene()
 
     logToView({ type: 'progress', message: 'Preparing to display' })
 
@@ -1913,15 +1921,6 @@ const loadBoardUI = async () => {
   // remote.getCurrentWebContents().openDevTools()
 }
 
-const updateBoardUI = async () => {
-  logToView({ type: 'progress', message: 'Rendering User Interface' })
-
-  document.querySelector('#canvas-caption').style.display = 'none'
-  renderViewMode()
-
-  await ensureBoardExists()
-  await renderScene()
-}
 
 // whenever the scene changes
 const renderScene = async () => {


### PR DESCRIPTION
Ensures that, when Storyboarder first loads a scene, it always verifies the scene content _first_, and _then_ renders it.
During verification, it checks for missing linked PSD files, removes links, and notifies the user.

Fixes #1702