### PR TITLE
Set Character name to match Character Preset name

### DIFF
--- a/src/js/shared/reducers/shot-generator.js
+++ b/src/js/shared/reducers/shot-generator.js
@@ -352,8 +352,7 @@ const defaultCharacterPreset = {
     mesomorphic: 0,
     ectomorphic: 0,
     endomorphic: 0
-  },
-  name: undefined
+  }
 }
 
 const defaultScenePreset = {

--- a/src/js/shot-generator/Components.js
+++ b/src/js/shot-generator/Components.js
@@ -929,8 +929,8 @@ const CharacterPresetsEditor = connect(
   }),
   {
     updateObject,
-    selectCharacterPreset: (id, characterPresetId, preset) => (dispatch, getState) => {
-      dispatch(updateObject(id, {
+    selectCharacterPreset: (sceneObject, characterPresetId, preset) => (dispatch, getState) => {
+      dispatch(updateObject(sceneObject.id, {
         // set characterPresetId
         characterPresetId,
 
@@ -1012,7 +1012,7 @@ const CharacterPresetsEditor = connect(
     const onSelectCharacterPreset = event => {
       let characterPresetId = event.target.value
       let preset = characterPresets[characterPresetId]
-      selectCharacterPreset(sceneObject.id, characterPresetId, preset)
+      selectCharacterPreset(sceneObject, characterPresetId, preset)
     }
 
     return h(

--- a/src/js/shot-generator/Components.js
+++ b/src/js/shot-generator/Components.js
@@ -949,8 +949,7 @@ const CharacterPresetsEditor = connect(
           endomorphic: preset.state.morphTargets.endomorphic
         },
 
-        // name: sceneObject.name || preset.name
-        name: preset.name
+        name: sceneObject.name || preset.name
       }))
     },
     createCharacterPreset: ({ id, name, sceneObject }) => (dispatch, getState) => {
@@ -990,8 +989,7 @@ const CharacterPresetsEditor = connect(
         // set the preset id
         characterPresetId: id,
         // use the preset’s name (if none assigned)
-        // name: sceneObject.name || preset.name
-        name: preset.name
+        name: sceneObject.name || preset.name
       }))
 
       // end the undo-able operation

--- a/src/js/shot-generator/Components.js
+++ b/src/js/shot-generator/Components.js
@@ -975,6 +975,9 @@ const CharacterPresetsEditor = connect(
         }
       }
       // create it
+
+      // start the undo-able operation
+      dispatch(undoGroupStart())
       dispatch(createCharacterPreset(preset))
 
       // save the presets file
@@ -982,6 +985,9 @@ const CharacterPresetsEditor = connect(
 
       // select the preset in the list
       dispatch(updateObject(sceneObject.id, { characterPresetId: id }))
+
+      // end the undo-able operation
+      dispatch(undoGroupEnd())
     }
   }
 )(

--- a/src/js/shot-generator/Components.js
+++ b/src/js/shot-generator/Components.js
@@ -975,7 +975,6 @@ const CharacterPresetsEditor = connect(
           }
         }
       }
-      // create it
 
       // start the undo-able operation
       dispatch(undoGroupStart())

--- a/src/js/shot-generator/Components.js
+++ b/src/js/shot-generator/Components.js
@@ -978,13 +978,18 @@ const CharacterPresetsEditor = connect(
 
       // start the undo-able operation
       dispatch(undoGroupStart())
+
+      // create the preset
       dispatch(createCharacterPreset(preset))
 
       // save the presets file
       saveCharacterPresets(getState())
 
-      // select the preset in the list
-      dispatch(updateObject(sceneObject.id, { characterPresetId: id }))
+      // update this object to use the preset
+      dispatch(updateObject(sceneObject.id, {
+        // set the preset id
+        characterPresetId: id,
+      }))
 
       // end the undo-able operation
       dispatch(undoGroupEnd())

--- a/src/js/shot-generator/Components.js
+++ b/src/js/shot-generator/Components.js
@@ -949,7 +949,8 @@ const CharacterPresetsEditor = connect(
           endomorphic: preset.state.morphTargets.endomorphic
         },
 
-        name: preset.state.name
+        // name: sceneObject.name || preset.name
+        name: preset.name
       }))
     },
     createCharacterPreset: ({ id, name, sceneObject }) => (dispatch, getState) => {
@@ -989,6 +990,9 @@ const CharacterPresetsEditor = connect(
       dispatch(updateObject(sceneObject.id, {
         // set the preset id
         characterPresetId: id,
+        // use the preset’s name (if none assigned)
+        // name: sceneObject.name || preset.name
+        name: preset.name
       }))
 
       // end the undo-able operation

--- a/src/js/shot-generator/Components.js
+++ b/src/js/shot-generator/Components.js
@@ -971,9 +971,7 @@ const CharacterPresetsEditor = connect(
             mesomorphic: sceneObject.morphTargets.mesomorphic,
             ectomorphic: sceneObject.morphTargets.ectomorphic,
             endomorphic: sceneObject.morphTargets.endomorphic
-          },
-
-          name: sceneObject.name
+          }
         }
       }
       // create it

--- a/src/js/shot-generator/Editor.js
+++ b/src/js/shot-generator/Editor.js
@@ -91,8 +91,6 @@ const {
   updateScenePreset,
   deleteScenePreset,
 
-  createCharacterPreset,
-
   createPosePreset,
   updatePosePreset,
   deletePosePreset,


### PR DESCRIPTION
When a character preset is created or selected, use the character preset name as the character’s name.

Closes #1570