### PR TITLE
Load all meshes when importing an environment model

### DIFF
--- a/src/js/express-xr/src/SceneManagerXR.js
+++ b/src/js/express-xr/src/SceneManagerXR.js
@@ -612,11 +612,11 @@ const SceneContent = ({
       soundBeam.current.stop()
 
       updateObjectHighlight(object)
-      useUpdateObject(object)
+      updateObjectForType(object)
     }
   }
 
-  const useUpdateObject = object => {
+  const updateObjectForType = object => {
     if (object.userData.type === 'character') {
       updateObject(object.userData.id, {
         x: object.position.x,

--- a/src/js/express-xr/src/SceneManagerXR.js
+++ b/src/js/express-xr/src/SceneManagerXR.js
@@ -385,7 +385,6 @@ const SceneContent = ({
       }
 
       if (intersection.object.userData.type === 'hitter' && intersection.object.parent.userData.character) {
-        if (!intersection.object.parent.userData.character) return
         intersection.object = intersection.object.parent.userData.character
       }
 

--- a/src/js/express-xr/src/SceneManagerXR.js
+++ b/src/js/express-xr/src/SceneManagerXR.js
@@ -254,8 +254,6 @@ const SceneContent = ({
   }
 
   const onSelectStart = event => {
-    soundSelect.current.play()
-
     const controller = event.target
     controller.pressed = true
 
@@ -271,7 +269,10 @@ const SceneContent = ({
     const intersections = getIntersections(controller, intersectArray.current)
 
     if (intersections.length > 0) {
-      onIntersection(controller, intersections)
+      let didMakeSelection = onIntersection(controller, intersections)
+      if (didMakeSelection) {
+        soundSelect.current.play()
+      }
     } else {
       setSelectedObject(0)
       selectedObjRef.current = null
@@ -279,13 +280,14 @@ const SceneContent = ({
     }
   }
 
+  // returns true if selection was successful
   const onIntersection = (controller, intersections) => {
       let intersection = intersections[0]
-      if (intersection.object.userData.type === 'bone') return
+      if (intersection.object.userData.type === 'bone') return true
 
       if (intersection.object.userData.type === 'slider') {
         controller.intersections = intersections
-        return
+        return true
       }
 
       if (intersection.object.userData.type === 'view') {
@@ -379,7 +381,7 @@ const SceneContent = ({
           }
         }
 
-        return
+        return true
       }
 
       if (intersection.object.userData.type === 'hitter' && intersection.object.parent.userData.character) {
@@ -392,7 +394,7 @@ const SceneContent = ({
       // is this probably NOT a scene object?
       // (used to exclude environment meshes for example)
       if (object.userData.id == null) {
-        return
+        return false
       }
 
       setSelectedObject(id)
@@ -451,6 +453,8 @@ const SceneContent = ({
         if (!objMaterial.emissive) return
         objMaterial.emissive.b = 0.15
       }
+
+      return true
   }
 
   const onChangeGuiMode = mode => {

--- a/src/js/express-xr/src/SceneManagerXR.js
+++ b/src/js/express-xr/src/SceneManagerXR.js
@@ -389,6 +389,12 @@ const SceneContent = ({
 
       let object = findParent(intersection.object)
       const { id } = object
+      // is this probably NOT a scene object?
+      // (used to exclude environment meshes for example)
+      if (object.userData.id == null) {
+        return
+      }
+
       setSelectedObject(id)
       selectedObjRef.current = scene.getObjectById(id)
       setHideArray(createHideArray(scene))
@@ -611,8 +617,12 @@ const SceneContent = ({
       controller.userData.selected = undefined
       soundBeam.current.stop()
 
-      updateObjectHighlight(object)
-      updateObjectForType(object)
+      // is this probably a scene object?
+      // (used to exclude environment meshes for example)
+      if (object.userData.id) {
+        updateObjectHighlight(object)
+        updateObjectForType(object)
+      }
     }
   }
 

--- a/src/js/express-xr/src/components/SGWorld.js
+++ b/src/js/express-xr/src/components/SGWorld.js
@@ -1,6 +1,17 @@
 const { useEffect, useRef, useMemo } = (React = require('react'))
 const buildSquareRoom = require('../../../shot-generator/build-square-room')
 
+const onlyOfTypes = require('../../../shot-generator/only-of-types')
+
+const materialFactory = () => new THREE.MeshToonMaterial({
+  color: 0xffffff,
+  emissive: 0x0,
+  specular: 0x0,
+  skinning: true,
+  shininess: 0,
+  flatShading: false
+})
+
 const SGWorld = ({ groundTexture, wallTexture, world, modelData }) => {
   const ambientLight = useRef(null)
   const directionalLight = useRef(null)
@@ -28,25 +39,16 @@ const SGWorld = ({ groundTexture, wallTexture, world, modelData }) => {
   const environmentObject = useMemo(() => {
     if (!modelData) return null
 
-    const g = new THREE.Group()
+    let g = new THREE.Group()
 
-    modelData.scene.children.forEach(child => {
-      if (child.type === 'Mesh') {
-        let m = child.clone()
-    
-        const material = new THREE.MeshToonMaterial({
-          color: 0xffffff,
-          emissive: 0x0,
-          specular: 0x0,
-          skinning: true,
-          shininess: 0,
-          flatShading: false
-        })
-        m.material = material
-    
-        g.add(m)
-      }
+    let sceneData = onlyOfTypes(modelData.scene.clone(), ['Scene', 'Mesh', 'Group'])
+
+    // update all Mesh textures
+    sceneData.traverse(child => {
+      if (child.isMesh) { child.material = materialFactory() }
     })
+
+    sceneData.children.forEach(child => g.add(child))
 
     return g
   }, [modelData])

--- a/src/js/express-xr/src/components/SGWorld.js
+++ b/src/js/express-xr/src/components/SGWorld.js
@@ -48,7 +48,7 @@ const SGWorld = ({ groundTexture, wallTexture, world, modelData }) => {
       if (child.isMesh) { child.material = materialFactory() }
     })
 
-    sceneData.children.forEach(child => g.add(child))
+    g.add( ...sceneData.children )
 
     return g
   }, [modelData])

--- a/src/js/shot-generator/World.js
+++ b/src/js/shot-generator/World.js
@@ -180,10 +180,7 @@ const useEnvironmentModel = (world, scene, { modelData}) => {
       let g = new THREE.Group()
       let scene = sanitize(modelData.scene.clone())
 
-      // add scene and children to group
-      g.add(scene)
-      // uncomment and use this instead to only add scene children
-      // scene.children.forEach(child => g.add(child))
+      scene.children.forEach(child => g.add(child))
 
       setGroup(g)
     } else {

--- a/src/js/shot-generator/World.js
+++ b/src/js/shot-generator/World.js
@@ -6,6 +6,7 @@ const { useRef, useEffect, useState } = React
 const path = require('path')
 
 const buildSquareRoom = require('./build-square-room')
+const onlyOfTypes = require('./only-of-types')
 
 // TODO use functions of ModelLoader?
 require('../vendor/three/examples/js/loaders/GLTFLoader')
@@ -153,24 +154,6 @@ const useEnvironmentModel = (world, scene, { modelData}) => {
     shininess: 0,
     flatShading: false
   })
-
-  // remove any object with a type that is not on the allowlist
-  const onlyOfTypes = (object3d, allowlist) => {
-    let removable = []
-
-    object3d.traverse(child => {
-      // if we don't allow this type of Object3d ...
-      if ( ! allowlist.includes(child.type) ) {
-        // ... mark it for removal
-        removable.push(child)
-      }
-    })
-    // remove the marked objects
-    removable.forEach(child => child.parent.remove(child))
-
-    // return the modified scene
-    return object3d
-  }
 
   useEffect(() => {
     if (modelData) {

--- a/src/js/shot-generator/World.js
+++ b/src/js/shot-generator/World.js
@@ -18,6 +18,15 @@ const imageLoader = new THREE.ImageLoader(loadingManager)
 
 objLoader.setLogging(false, false)
 
+const materialFactory = () => new THREE.MeshToonMaterial({
+  color: 0xffffff,
+  emissive: 0x0,
+  specular: 0x0,
+  skinning: true,
+  shininess: 0,
+  flatShading: false
+})
+
 const useGround = (world, scene) => {
   const [loaded, setLoaded] = useState(false)
 
@@ -145,15 +154,6 @@ const useRoom = (world, scene) => {
 
 const useEnvironmentModel = (world, scene, { modelData}) => {
   const [group, setGroup] = useState(null)
-
-  const materialFactory = () => new THREE.MeshToonMaterial({
-    color: 0xffffff,
-    emissive: 0x0,
-    specular: 0x0,
-    skinning: true,
-    shininess: 0,
-    flatShading: false
-  })
 
   useEffect(() => {
     if (modelData) {

--- a/src/js/shot-generator/World.js
+++ b/src/js/shot-generator/World.js
@@ -166,7 +166,7 @@ const useEnvironmentModel = (world, scene, { modelData}) => {
         if (child.isMesh) { child.material = materialFactory() }
       })
 
-      sceneData.children.forEach(child => g.add(child))
+      g.add( ...sceneData.children )
 
       setGroup(g)
     } else {

--- a/src/js/shot-generator/only-of-types.js
+++ b/src/js/shot-generator/only-of-types.js
@@ -1,0 +1,19 @@
+// remove any object with a type that is not on the allowlist
+const onlyOfTypes = (object3d, allowlist) => {
+  let removable = []
+
+  object3d.traverse(child => {
+    // if we don't allow this type of Object3d ...
+    if ( ! allowlist.includes(child.type) ) {
+      // ... mark it for removal
+      removable.push(child)
+    }
+  })
+
+  // remove the marked objects
+  removable.forEach(child => child.parent.remove(child))
+
+  return object3d
+}
+
+module.exports = onlyOfTypes


### PR DESCRIPTION
- Filters out any objects that we don't support from the model data file.
- Then, adds all remaining meshes _and groups of meshes_ (instead of just the first level of children) to the scene

Fixes #1716