### PR TITLE
Use reference layer opacity slider for shot generator layer also

### DIFF
--- a/src/js/window/layers-editor.js
+++ b/src/js/window/layers-editor.js
@@ -127,6 +127,10 @@ class LayersEditor extends EventEmitter {
     this.setReferenceOpacity(value)
   }
 
+  getReferenceOpacity () {
+    return this.storyboarderSketchPane.sketchPane.layers.findByName('reference').getOpacity()
+  }
+
   setReferenceOpacity (value) {
     console.log('LayersEditor#setReferenceOpacity', value)
     this.storyboarderSketchPane.sketchPane.layers.findByName('reference').setOpacity(value)

--- a/src/js/window/layers-editor.js
+++ b/src/js/window/layers-editor.js
@@ -9,14 +9,6 @@ class LayersEditor extends EventEmitter {
     this.sfx = sfx
     this.notifications = notifications
 
-    this.model = {
-      layers: {
-        [this.storyboarderSketchPane.sketchPane.layers.findByName('reference').index]: {
-          opacity: DEFAULT_REFERENCE_LAYER_OPACITY
-        }
-      }
-    }
-
     // document.querySelector('.layers-ui-notes-visible').addEventListener('pointerdown', this.toggleLayer.bind(this, 3))
     document
       .querySelector('.layers-ui-notes-clear')
@@ -69,7 +61,7 @@ class LayersEditor extends EventEmitter {
         this.setReferenceOpacity(event.target.value / 100)
       })
 
-    this.render(this.model)
+    this.render()
   }
 
   // NOT USED
@@ -113,27 +105,39 @@ class LayersEditor extends EventEmitter {
     )
   }
 
-  present (data) {
-    if (data.opacity) {
-      this.model.layers[data.opacity.index].opacity = data.opacity.value
-      this.render(this.model)
-      this.emit('opacity', data.opacity)
+  loadReferenceOpacity (board) {
+    console.log('LayersEditor#loadReferenceOpacity')
+    let value = DEFAULT_REFERENCE_LAYER_OPACITY
+
+    // if there is layer data ...
+    if (board.layers) {
+      // ... prefer the reference layer opacity ...
+      if (board.layers.reference && board.layers.reference.opacity != null) {
+        value = board.layers.reference.opacity
+        console.log('...from reference', value)
+
+      // ... otherwise, try for the shot-generator opacity ...
+      } else if (board.layers['shot-generator'] && board.layers['shot-generator'].opacity != null) {
+        value = board.layers['shot-generator'].opacity
+        console.log('...from shot-generator', value)
+
+      }
     }
+
+    this.setReferenceOpacity(value)
   }
 
-  // public method
-  // value = 0...1.0
   setReferenceOpacity (value) {
-    this.present({ opacity: { index: this.storyboarderSketchPane.sketchPane.layers.findByName('reference').index, value } })
+    console.log('LayersEditor#setReferenceOpacity', value)
+    this.storyboarderSketchPane.sketchPane.layers.findByName('reference').setOpacity(value)
+    this.storyboarderSketchPane.sketchPane.layers.findByName('shot-generator').setOpacity(value)
+    this.render()
+    this.emit('opacity')
   }
 
-  getReferenceOpacity () {
-    return this.model.layers[this.storyboarderSketchPane.sketchPane.layers.findByName('reference').index].opacity
-  }
-
-  render (model) {
-    let index = this.storyboarderSketchPane.sketchPane.layers.findByName('reference').index
-    let value = model.layers[index].opacity
+  render () {
+    let value = this.storyboarderSketchPane.sketchPane.layers.findByName('reference').getOpacity()
+    console.log('LayersEditor#render', value)
     document.querySelector('.layers-ui-reference-opacity').value = value * 100
   }
 }

--- a/src/js/window/layers-editor.js
+++ b/src/js/window/layers-editor.js
@@ -106,7 +106,6 @@ class LayersEditor extends EventEmitter {
   }
 
   loadReferenceOpacity (board) {
-    console.log('LayersEditor#loadReferenceOpacity')
     let value = DEFAULT_REFERENCE_LAYER_OPACITY
 
     // if there is layer data ...
@@ -114,13 +113,9 @@ class LayersEditor extends EventEmitter {
       // ... prefer the reference layer opacity ...
       if (board.layers.reference && board.layers.reference.opacity != null) {
         value = board.layers.reference.opacity
-        console.log('...from reference', value)
-
       // ... otherwise, try for the shot-generator opacity ...
       } else if (board.layers['shot-generator'] && board.layers['shot-generator'].opacity != null) {
         value = board.layers['shot-generator'].opacity
-        console.log('...from shot-generator', value)
-
       }
     }
 
@@ -132,7 +127,6 @@ class LayersEditor extends EventEmitter {
   }
 
   setReferenceOpacity (value) {
-    console.log('LayersEditor#setReferenceOpacity', value)
     this.storyboarderSketchPane.sketchPane.layers.findByName('reference').setOpacity(value)
     this.storyboarderSketchPane.sketchPane.layers.findByName('shot-generator').setOpacity(value)
     this.render()
@@ -141,7 +135,6 @@ class LayersEditor extends EventEmitter {
 
   render () {
     let value = this.storyboarderSketchPane.sketchPane.layers.findByName('reference').getOpacity()
-    console.log('LayersEditor#render', value)
     document.querySelector('.layers-ui-reference-opacity').value = value * 100
   }
 }

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -1358,13 +1358,14 @@ const loadBoardUI = async () => {
     await updateThumbnailDisplayFromFile(index)
     */
   })
-  storyboarderSketchPane.on('requestPointerDown', () => {
+  storyboarderSketchPane.on('beforePointerDown', () => {
     // if artist is drawing on the reference layer, ensure it has opacity
     if (
       store.getState().toolbar.activeTool === 'light-pencil' &&
       storyboarderSketchPane.getLayerOpacity(
-        storyboarderSketchPane.sketchPane.layers.findByName('reference').index) === 0
-      ) {
+        storyboarderSketchPane.sketchPane.layers.findByName('reference').index
+      ) === 0
+    ) {
       layersEditor.setReferenceOpacity(exporterCommon.DEFAULT_REFERENCE_LAYER_OPACITY)
     }
   })

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -2356,8 +2356,7 @@ let saveImageFile = async () => {
           url: filename,
 
           // special case for reference layer
-          // initialize the opacity from the LayersEditor's current value
-          // TODO keep the temp ref opacity val somewhere useful (see: #1116)
+          // match whatever the slider says
           opacity: (index === storyboarderSketchPane.sketchPane.layers.findByName('reference').index)
             ? layersEditor.getReferenceOpacity()
             : undefined

--- a/src/js/window/storyboarder-sketch-pane.js
+++ b/src/js/window/storyboarder-sketch-pane.js
@@ -620,6 +620,9 @@ class LineDrawingStrategy {
   }
 
   _onPointerDown (e) {
+    // trigger layer opacity check
+    this.context.emit('beforePointerDown')
+
     let nextEvent
 
     if (this.state.started) {
@@ -672,9 +675,6 @@ class LineDrawingStrategy {
 
     // audible event for Sonifier
     this.context.emit('pointerdown', this.context.sketchPane.localizePoint(nextEvent))
-
-    // just triggers layer opacity check
-    this.context.emit('requestPointerDown')
   }
 
   _onPointerMove (e) {
@@ -787,6 +787,9 @@ class DrawingStrategy {
 
   // TODO could store multiErase status / erase layer array in a reducer?
   _onPointerDown (e) {
+    // trigger layer opacity check
+    this.context.emit('beforePointerDown')
+
     this._idleTimer && this._idleTimer.reset()
 
     this.context.store.dispatch({ type: 'TOOLBAR_MODE_STATUS_SET', payload: 'busy', meta: { scope: 'local' } })
@@ -837,9 +840,6 @@ class DrawingStrategy {
 
     // audible event for Sonifier
     this.context.emit('pointerdown', this.context.sketchPane.localizePoint(e))
-
-    // just triggers layer opacity check
-    this.context.emit('requestPointerDown')
   }
 
   _onPointerMove (e) {


### PR DESCRIPTION
- reference layer slider value is remembered<sup>*</sup>

- default opacity is 75%
- if you set the opacity to 0% and start drawing on the reference layer, it jumps to 75% so you can see what you're drawing
- any time you save a shot generator shot, it’s forced to 100%

Fixes #1116

<b id="f1">*</b> <i>as long as you have either a reference layer drawing or a shot generator shot. if you've never drawn on the reference layer or added a shot generator shot, and you set the value, we don't have any layer data to store it on, so it is not remembered. you must draw or add a shot to store it.</i>