### PR TITLE
Saving Pole Targets position across Xr and SG

### DIFF
--- a/src/js/shared/IK/IkHelper.js
+++ b/src/js/shared/IK/IkHelper.js
@@ -52,6 +52,7 @@ class IKHelper extends THREE.Object3D
             {
                 let pos = intializedMesh.position;
                 mesh.position.set(pos.x, pos.y, pos.z);
+                this.intializedSkinnedMesh.worldToLocal(mesh.position);
                 mesh.updateMatrixWorld();
                 mesh.userData.isInitialized = true;
             }
@@ -101,7 +102,8 @@ class IKHelper extends THREE.Object3D
             else
             {
                 this.poleTargets.attach(this.selectedControlPoint);
-                let worldPosition = this.selectedControlPoint.position;
+                this.poleTargets.updateMatrixWorld(true)
+                let worldPosition = this.selectedControlPoint.worldPosition();
                 this.selectedControlPoint.userData.isInitialized = true;
                 let poleTargets = {};
                 poleTargets[this.selectedControlPoint.name] = 

--- a/src/js/shared/IK/objects/IkObjects/Ragdoll.js
+++ b/src/js/shared/IK/objects/IkObjects/Ragdoll.js
@@ -194,6 +194,16 @@ class Ragdoll extends IkObject
             {
                 poleTarget = new PoleTarget();
                 poleTarget.mesh = poleTargetMesh;
+                
+                let boneMatrix = this.resourceManager.getMatrix4();
+                this.takeBoneInTheMeshSpace(this.rigMesh, poleTargetMesh, boneMatrix);
+                let bonePosition = new THREE.Vector3().setFromMatrixPosition(boneMatrix)
+                this.takeBoneInTheMeshSpace(this.rigMesh, this.hips, boneMatrix);
+                let hipsPosition = new THREE.Vector3().setFromMatrixPosition(boneMatrix)
+                this.resourceManager.release(boneMatrix);
+
+                let hipsOffset = bonePosition.sub(hipsPosition);
+                poleTarget.offsetWithoutHips = hipsOffset.clone();
             }
             else
             {
@@ -277,7 +287,7 @@ class Ragdoll extends IkObject
             let targetPosition = hipsTarget.position;
             let poleOffset = constraint.poleTarget.offsetWithoutHips;
             let mesh = constraint.poleTarget.mesh;
-            if(constraint.poleTarget.mesh.name === "leftArmPole" || constraint.poleTarget.mesh.name === "rightArmPole")
+            if((mesh.name === "leftArmPole" || mesh.name === "rightArmPole") && !mesh.userData.isInitialized)
             {
                 mesh.position.set(targetPosition.x + poleOffset.x, targetPosition.y + poleOffset.y, targetPosition.z - poleOffset.z);
                 mesh.rotateAroundPoint(targetPosition, armsAngleAxis.axis, armsAngleAxis.angle);

--- a/src/js/shot-generator/Character.js
+++ b/src/js/shot-generator/Character.js
@@ -545,9 +545,9 @@ const Character = React.memo(({
         object.current.bonesHelper.add(cone)
       }
       if ( !isCustomModel(props.model) ) {
-        SGIkHelper.getInstance().initialize(scene, object.current, object.current.userData.modelSettings.height, object.current.userData.mesh)
+        SGIkHelper.getInstance().initialize(scene, object.current, object.current.userData.modelSettings.height, object.current.userData.mesh, props)
         object.current.add(SGIkHelper.getInstance())
-        SGIkHelper.getInstance().updateMatrixWorld(true);
+        SGIkHelper.getInstance().updateMatrixWorld(true)
       }
     } else {
       object.current.remove(SGIkHelper.getInstance())
@@ -585,6 +585,13 @@ const Character = React.memo(({
 
     object.current.orthoIcon.setSelected(isSelected)
   }, [props.model, isSelected, ready])
+
+  // Watches for poletargets changes and applies them 
+  useEffect(() => {
+    if(!ready) return
+    if(!props.poleTargets) return
+    SGIkHelper.getInstance().updatePoleTarget(object.current, props.poleTargets)
+  }, [props.poleTargets, ready])
 
   useEffect(() => {
     if (!ready) return


### PR DESCRIPTION
Implemented saving of changed pole targets position in VR and applying them to SG.
Old boards with changed pole targets position will have their positions in a different place than before because the way of saving pole targets position has changed. Simply move them to a new position.