### PR TITLE
Fixed second camera can't rotate bones

### DIFF
--- a/src/js/shot-generator/Character.js
+++ b/src/js/shot-generator/Character.js
@@ -398,6 +398,7 @@ const Character = React.memo(({
   useEffect(() => {
     if(!ready || !camera) return
     SGIkHelper.getInstance().setCamera(camera)
+    boneRotationControl.current.setCamera(camera)
   }, [camera, ready])
   //#endregion
 


### PR DESCRIPTION
Fixed the inability to rotate bones when a non-initial camera is selected  