### PR TITLE
Volume: show file names for custom images

### DIFF
--- a/src/css/shot-generator.css
+++ b/src/css/shot-generator.css
@@ -1317,6 +1317,7 @@ div.fatal-error-screen__report::selection {
 
 .select .select__single-value {
   color: #eee;
+  text-transform: none;
 }
 
 .select .select__placeholder {

--- a/src/js/shot-generator/components/InspectedElement/GeneralInspector/Volume.js
+++ b/src/js/shot-generator/components/InspectedElement/GeneralInspector/Volume.js
@@ -17,9 +17,9 @@ const selectOptions = [
   {
     label: "Built-in",
     options: [
-      { label: "rain", value: "rain1,rain2" },
-      { label: "fog", value: "fog1,fog2" },
-      { label: "explosion", value: "debris,explosion" }
+      { label: "Rain", value: "rain1,rain2" },
+      { label: "Fog", value: "fog1,fog2" },
+      { label: "Explosion", value: "debris,explosion" }
     ]
   }
 ]
@@ -124,7 +124,13 @@ const VolumeInspector = React.memo(({updateObject, sceneObject, storyboarderFile
         <div className="input-group__input">
           <Select
             label="Select Layer Images"
-            value={ selectedFile }
+            value={{
+              label:
+                typeof selectedFile.label == 'string'
+                  ? selectedFile.label
+                  : selectedFile.label.map(s => path.basename(s)).join(', '),
+              value: selectedFile.value
+            }}
             options={ selectOptions }
             onSetValue={(item) => { selectAttachment(item) }}
             />

--- a/src/js/shot-generator/components/InspectedElement/GeneralInspector/Volume.js
+++ b/src/js/shot-generator/components/InspectedElement/GeneralInspector/Volume.js
@@ -24,6 +24,10 @@ const selectOptions = [
   }
 ]
 
+const createLabel = (ids) => {
+  return ids.map(s => path.basename(s)).join(', ');
+} 
+
 const VolumeInspector = React.memo(({updateObject, sceneObject, storyboarderFilePath}) => {
   const {id, ...props} = sceneObject
 
@@ -31,7 +35,7 @@ const VolumeInspector = React.memo(({updateObject, sceneObject, storyboarderFile
     let builtInOptions = Object.values(Object.values(selectOptions)[1].options)
     let builtInOption = builtInOptions.find(object => object.value.includes(sceneObject.volumeImageAttachmentIds[0]))
     if(!builtInOption) {
-      return {label: sceneObject.volumeImageAttachmentIds, value: sceneObject.volumeImageAttachmentIds }
+      return {label: createLabel(sceneObject.volumeImageAttachmentIds), value: sceneObject.volumeImageAttachmentIds }
     } else {
       return builtInOption
     }
@@ -67,8 +71,7 @@ const VolumeInspector = React.memo(({updateObject, sceneObject, storyboarderFile
 
           if (ids.length) {
             updateObject(sceneObject.id, { volumeImageAttachmentIds: ids })
-            let label = ids.map(s => path.basename(s)).join(', ');
-            setSelectedFile({label:label, value: ids})
+            setSelectedFile({label: createLabel(ids), value: ids})
           }
       }
 

--- a/src/js/shot-generator/components/InspectedElement/GeneralInspector/Volume.js
+++ b/src/js/shot-generator/components/InspectedElement/GeneralInspector/Volume.js
@@ -67,7 +67,8 @@ const VolumeInspector = React.memo(({updateObject, sceneObject, storyboarderFile
 
           if (ids.length) {
             updateObject(sceneObject.id, { volumeImageAttachmentIds: ids })
-            setSelectedFile({label:ids, value: ids})
+            let label = ids.map(s => path.basename(s)).join(', ');
+            setSelectedFile({label:label, value: ids})
           }
       }
 
@@ -125,10 +126,7 @@ const VolumeInspector = React.memo(({updateObject, sceneObject, storyboarderFile
           <Select
             label="Select Layer Images"
             value={{
-              label:
-                typeof selectedFile.label == 'string'
-                  ? selectedFile.label
-                  : selectedFile.label.map(s => path.basename(s)).join(', '),
+              label:selectedFile.label,
               value: selectedFile.value
             }}
             options={ selectOptions }

--- a/src/js/shot-generator/components/Select/index.js
+++ b/src/js/shot-generator/components/Select/index.js
@@ -2,7 +2,14 @@ import React, {useEffect, useRef} from 'react'
 import ReactSelect from 'react-select'
 
 const defaultOnSetValue = value => {}
-
+const style = {
+  control: base => ({
+    ...base,
+    border: 0,
+    // This line disable the blue border
+    boxShadow: "none"
+  })
+}
 const Select = React.memo(({
     value = null,
     label = null,
@@ -23,6 +30,7 @@ const Select = React.memo(({
     placeholder={ label }
     onChange={ callbackRef.current } 
     isDisabled={ disabled }
+    styles={ style }
     //menuIsOpen: true,// useful to debug
     isSearchable={ false }
     menuPlacement="auto"


### PR DESCRIPTION
Volume Select currently shows the entire relative path as the Select label:

![image](https://user-images.githubusercontent.com/23459/81992213-96ac4b00-9608-11ea-92f8-eb473dbe2c1e.png)

This PR changes it to be somewhat more legible:

![image](https://user-images.githubusercontent.com/23459/81992057-492fde00-9608-11ea-9bfc-45db11343c28.png)

Would be nice to also reduce the font size, and fix the focus outline (which is clipped and only shows blue on the left of the input), but not necessary for now.

/cc @VladStepura 