### PR TITLE
Shot Generator: fix bug where -camera-plot.png was not saved to file

### DIFF
--- a/src/js/shot-generator/components/Three/SaveShot.js
+++ b/src/js/shot-generator/components/Three/SaveShot.js
@@ -96,14 +96,13 @@ const SaveShot = connect(
         }) } else {
             let plotImage = renderImagesForBoard()
             setTimeout(() => {
-                withState((dispatch, state) => {
+            withState((dispatch, state) => {
                     ipcRenderer.send('saveShotPlot', {
                         plotImage: plotImage,
                         currentBoard: state.board.uid
                     })
                 })
-              }, 100)
-     
+            }, 0)
         }
     }, [scene])
   
@@ -121,9 +120,9 @@ const SaveShot = connect(
     const renderImagesForBoard = (dispatch, state) => {
         let width = isPlot ? 900 : Math.ceil(900 * state.aspectRatio)
         let imageRenderCamera = camera.clone()
-        imageRenderCamera.layers.set(SHOT_LAYERS)
         // render the image
         if(!isPlot) {
+            imageRenderCamera.layers.set(SHOT_LAYERS)
             imageRenderCamera.aspect = state.aspectRatio
             imageRenderCamera.updateProjectionMatrix()
         }


### PR DESCRIPTION
## Bug description
The plot of the scene sometimes won't save on **Save to board** and saves for the improper scene on the **Insert as a new board**. 
Plot content isn't fully rendered on scene saving.

## Root cause
The problem in decoupling of saving of the board content and the plot image saving. 
Scene plot renders using improper layers filter

## Solution description
The solution which was used is to add saving status. This status helps to understand whatever new scene was created and ready to use we need to add a callback(for plot saving) which will be called once scene data is saved.
For plot rendered content the camera which set layers was changed
