### PR TITLE
Add “Show Log File…” to Help menu

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -2,6 +2,7 @@ const { Menu, app } = require('electron').remote
 const { ipcRenderer, shell } = require('electron')
 const isDev = require('electron-is-dev')
 const { getInitialStateRenderer } = require('electron-redux')
+const log = require('electron-log')
 
 // TODO subscribe to store, update menu when keymap changes
 const configureStore = require('./shared/store/configureStore')
@@ -47,8 +48,15 @@ SubMenuFragments.help = [
     click () { shell.openExternal('https://wonderunit.com/storyboarder/faq') }
   },
   {
+    type: 'separator'
+  },
+  {
     label: 'Found a bug? Submit an issue!!!',
     click () { shell.openExternal('https://github.com/wonderunit/storyboarder/issues/new') }
+  },
+  {
+    label: 'Show Log File…',
+    click () { shell.showItemInFolder(log.transports.file.findLogPath()) }
   }
 ]
 SubMenuFragments.windowing = [


### PR DESCRIPTION
Frequently we’ll ask for the log file when troubleshooting. This would help users locate it quickly.

![image](https://user-images.githubusercontent.com/23459/87570845-d6d28d00-c68e-11ea-9c54-678123046c61.png)

