### PR TITLE
Character Rotation

### DIFF
--- a/src/js/shared/IK/objects/ObjectRotationControl.js
+++ b/src/js/shared/IK/objects/ObjectRotationControl.js
@@ -17,8 +17,10 @@ class ObjectRotationControl
         this.isEnabled = false;
         this.customOnMouseDownAction = null;
         this.customOnMouseUpAction = null;
+        this.offsetObject = new THREE.Object3D()
+        this.scene.add(this.offsetObject)
     }
-
+    
     set IsEnabled(value) 
     {
         this.control.enabled = value
@@ -40,7 +42,7 @@ class ObjectRotationControl
         this.control.characterId = characterId;
     }
 
-    selectObject(object, hitmeshid)
+    selectObject(object, hitmeshid, offset = null)
     {
         if(this.object !== null && !this.isSelected(object))
         {
@@ -49,10 +51,15 @@ class ObjectRotationControl
         }
         if (object)
         {
-            this.scene.add(this.control);
+            this.offsetObject.add(this.control);
             this.control.addToScene();
         }
         this.control.objectId = hitmeshid;
+        if(offset) {
+            this.offsetObject.position.copy(offset)
+        } else {
+            this.offsetObject.position.set(0, 0, 0)
+        }
         this.control.attach(object);
         this.object = object;
         this.control.addEventListener("transformMouseDown", this.onMouseDown, false);
@@ -89,6 +96,7 @@ class ObjectRotationControl
 
     cleanUp()
     {
+        this.scene.remove(this.offsetObject)
         this.deselectObject();
         this.control.cleanUp();
         this.control = null;

--- a/src/js/shared/IK/objects/ObjectRotationControl.js
+++ b/src/js/shared/IK/objects/ObjectRotationControl.js
@@ -19,6 +19,7 @@ class ObjectRotationControl
         this.customOnMouseUpAction = null;
         this.offsetObject = new THREE.Object3D()
         this.scene.add(this.offsetObject)
+        this.offsetObject.userData.type = 'controlTarget'
     }
     
     set IsEnabled(value) 
@@ -58,6 +59,7 @@ class ObjectRotationControl
         if(offset) {
             this.offsetObject.position.copy(offset)
             this.offsetObject.position.y -= object.position.y
+            this.offsetObject.updateMatrixWorld(true)
         } else {
             this.offsetObject.position.set(0, 0, 0)
         }

--- a/src/js/shared/IK/objects/ObjectRotationControl.js
+++ b/src/js/shared/IK/objects/ObjectRotationControl.js
@@ -57,6 +57,7 @@ class ObjectRotationControl
         this.control.objectId = hitmeshid;
         if(offset) {
             this.offsetObject.position.copy(offset)
+            this.offsetObject.position.y -= object.position.y
         } else {
             this.offsetObject.position.set(0, 0, 0)
         }

--- a/src/js/shot-generator/components/Three/Character.js
+++ b/src/js/shot-generator/components/Three/Character.js
@@ -10,6 +10,31 @@ import { SHOT_LAYERS } from '../../utils/ShotLayers'
 import {patchMaterial, setSelected} from '../../helpers/outlineMaterial'
 import isUserModel from '../../helpers/isUserModel'
 import { axis } from "../../../shared/IK/utils/TransformControls"
+let boneWorldPosition = new THREE.Vector3()
+let worldPositionHighestBone = new THREE.Vector3()
+
+const findHighestBone = (object) =>
+{   
+    let highestBone = null
+    let bones = object.skeleton.bones
+    for(let i = 0; i < bones.length; i ++)
+    {
+        let bone = bones[i]
+        if(!highestBone)
+        {
+            highestBone = bone
+            continue
+        }
+        bone.getWorldPosition(boneWorldPosition)
+        highestBone.getWorldPosition(worldPositionHighestBone)
+
+        if(boneWorldPosition.y > worldPositionHighestBone.y)
+        {
+            highestBone = bone
+        }
+    }
+    return highestBone
+}
 
 const Character = React.memo(({ path, sceneObject, modelSettings, isSelected, selectedBone, updateCharacterSkeleton, updateCharacterIkSkeleton, renderData, withState, ...props}) => {
     const {asset: gltf} = useAsset(path)
@@ -324,6 +349,7 @@ const Character = React.memo(({ path, sceneObject, modelSettings, isSelected, se
         }
         ref.current.add(BonesHelper.getInstance())
         //#region Character's object rotation control
+        let highestBone = findHighestBone(lod.children[0])
         props.objectRotationControl.setCharacterId(ref.current.uuid)
         props.objectRotationControl.control.canSwitch = false
         props.objectRotationControl.isEnabled = true
@@ -332,7 +358,10 @@ const Character = React.memo(({ path, sceneObject, modelSettings, isSelected, se
           props.updateObject(sceneObject.id, {
             rotation: euler.y,
           } )})
-        props.objectRotationControl.selectObject(ref.current, ref.current.uuid)
+        let highestPoint = highestBone.worldPosition()
+        highestPoint.x = 0
+        highestPoint.z = 0
+        props.objectRotationControl.selectObject(ref.current, ref.current.uuid, highestPoint)
         props.objectRotationControl.control.setShownAxis(axis.Y_axis)
         props.objectRotationControl.IsEnabled = !sceneObject.locked
         //#endregion

--- a/src/js/shot-generator/components/Three/InteractionManager.js
+++ b/src/js/shot-generator/components/Three/InteractionManager.js
@@ -94,7 +94,6 @@ const InteractionManager = connect(
     const [lastDownId, setLastDownId] = useState()
     const [dragTarget, setDragTarget] = useState()
     const [pointerDownEvent, setOnPointDown] = useState()
-    const isCtrlPressed = useRef(false)
     const [pointerUpEvent, setOnPointUp] = useState()
     const [isCameraControlsEnabled, enableCameraControls] = useState(true)
     const { prepareDrag, drag, updateStore, endDrag } = useDraggingManager(false)
@@ -339,11 +338,11 @@ const InteractionManager = connect(
         if(dragTarget.target.userData.type === 'character') {
           let ikRig = SGIkHelper.getInstance().ragDoll;
           if(!ikRig || !ikRig.isEnabledIk && !ikRig.hipsMoving && !ikRig.hipsMouseDown) {
-            drag({ x, y }, dragTarget.target, camera, selections, isCtrlPressed.current)
+            drag({ x, y }, dragTarget.target, camera, selections, event.ctrlKey)
           }
         }
         else {
-          drag({ x, y }, dragTarget.target, camera, selections, isCtrlPressed.current)
+          drag({ x, y }, dragTarget.target, camera, selections, event.ctrlKey)
         }
       }
     }
@@ -429,31 +428,15 @@ const InteractionManager = connect(
         setLastDownId(null)
     }
 
-    const keyDown = (event) => {
-      if(event.ctrlKey) {
-        isCtrlPressed.current = true 
-      }
-    } 
-
-    const keyUp = (event) => {
-      if(event.ctrlKey) {
-        isCtrlPressed.current = false 
-      }
-    } 
-
     useLayoutEffect(() => {
       activeGL.domElement.addEventListener('pointerdown', onPointerDown)
       activeGL.domElement.addEventListener('pointermove', onPointerMove)
       activeGL.domElement.addEventListener('pointermove', throttleUpdateDraggableObject)
-      activeGL.domElement.addEventListener('keydown', keyDown)
-      activeGL.domElement.addEventListener('keyup', keyUp)
       window.addEventListener('pointerup', onPointerUp)
       return function cleanup () {
         activeGL.domElement.removeEventListener('pointerdown', onPointerDown)
         activeGL.domElement.removeEventListener('pointermove', onPointerMove)
         activeGL.domElement.removeEventListener('pointermove', throttleUpdateDraggableObject)
-        activeGL.domElement.removeEventListener('keydown', keyDown)
-        activeGL.domElement.removeEventListener('keyup', keyUp)
         window.removeEventListener('pointerup', onPointerUp)
       }
     }, [onPointerDown, onPointerUp, onPointerMove, activeGL])

--- a/src/js/shot-generator/components/Three/InteractionManager.js
+++ b/src/js/shot-generator/components/Three/InteractionManager.js
@@ -94,6 +94,7 @@ const InteractionManager = connect(
     const [lastDownId, setLastDownId] = useState()
     const [dragTarget, setDragTarget] = useState()
     const [pointerDownEvent, setOnPointDown] = useState()
+    const isCtrlPressed = useRef(false)
     const [pointerUpEvent, setOnPointUp] = useState()
     const [isCameraControlsEnabled, enableCameraControls] = useState(true)
     const { prepareDrag, drag, updateStore, endDrag } = useDraggingManager(false)
@@ -338,11 +339,11 @@ const InteractionManager = connect(
         if(dragTarget.target.userData.type === 'character') {
           let ikRig = SGIkHelper.getInstance().ragDoll;
           if(!ikRig || !ikRig.isEnabledIk && !ikRig.hipsMoving && !ikRig.hipsMouseDown) {
-            drag({ x, y }, dragTarget.target, camera, selections)
+            drag({ x, y }, dragTarget.target, camera, selections, isCtrlPressed.current)
           }
         }
         else {
-          drag({ x, y }, dragTarget.target, camera, selections)
+          drag({ x, y }, dragTarget.target, camera, selections, isCtrlPressed.current)
         }
       }
     }
@@ -427,16 +428,32 @@ const InteractionManager = connect(
     
         setLastDownId(null)
     }
-    
+
+    const keyDown = (event) => {
+      if(event.ctrlKey) {
+        isCtrlPressed.current = true 
+      }
+    } 
+
+    const keyUp = (event) => {
+      if(event.ctrlKey) {
+        isCtrlPressed.current = false 
+      }
+    } 
+
     useLayoutEffect(() => {
       activeGL.domElement.addEventListener('pointerdown', onPointerDown)
       activeGL.domElement.addEventListener('pointermove', onPointerMove)
       activeGL.domElement.addEventListener('pointermove', throttleUpdateDraggableObject)
+      activeGL.domElement.addEventListener('keydown', keyDown)
+      activeGL.domElement.addEventListener('keyup', keyUp)
       window.addEventListener('pointerup', onPointerUp)
       return function cleanup () {
         activeGL.domElement.removeEventListener('pointerdown', onPointerDown)
         activeGL.domElement.removeEventListener('pointermove', onPointerMove)
         activeGL.domElement.removeEventListener('pointermove', throttleUpdateDraggableObject)
+        activeGL.domElement.removeEventListener('keydown', keyDown)
+        activeGL.domElement.removeEventListener('keyup', keyUp)
         window.removeEventListener('pointerup', onPointerUp)
       }
     }, [onPointerDown, onPointerUp, onPointerMove, activeGL])


### PR DESCRIPTION
## Feature description
Moves the rotation gizmo to top of the character and adds rotation podium for character

## Solution description
Moving rotation gizmo seems logical cause most of the time you spend zoomed at the character top part and having gizmo at the top significantly simplify character adjusting. 
Character's rotation podium is an ability to rotate character on ctrl + dragging. It's an alternative way to rotate a character.

## Task 
- [x] Move rotation gizmo to the to of character
- [x] Create character rotation podium
