### PR TITLE
Fix for video export

### DIFF
--- a/src/js/exporters/ffmpeg.js
+++ b/src/js/exporters/ffmpeg.js
@@ -1,6 +1,5 @@
-const electronUtil = require('electron-util')
 const execa = require('execa')
-const ffmpeg = require('@ffmpeg-installer/ffmpeg')
+const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path.replace('app.asar', 'app.asar.unpacked');
 const fs = require('fs-extra')
 const path = require('path')
 const moment = require('moment')
@@ -9,7 +8,6 @@ const tmp = require('tmp')
 const boardModel = require('../models/board')
 const exporterCommon = require('../exporters/common')
 
-const ffmpegPath = electronUtil.fixPathForAsarUnpack(ffmpeg.path)
 
 // const durationRegex = /Duration: (\d\d:\d\d:\d\d.\d\d)/gm
 // const frameRegex = /frame=\s+(\d+)/gm


### PR DESCRIPTION
## Bug description
The video export doesn't work in the new release. #2107 

## Root cause
The file path for FFmpeg doesn't replaced properly. In the previous version of the storyboard, [Electron-utils](https://github.com/wonderunit/storyboarder/blob/efb823cd79303819c4c4ad691b6b6d341e868e03/src/js/exporters/ffmpeg.js#L12) was solving for file path change, but with the change of electron version, the way mainModule behave changed and the Electron-utils doesn't take this into consideration.

## Solution description
FFmpeg file path is manually changed from "app.asar" to "app.asar.unpacked" on the FFmpeg export