### PR TITLE
Fixed flatshaded environments

### DIFF
--- a/src/js/shot-generator/components/Three/Environment.js
+++ b/src/js/shot-generator/components/Three/Environment.js
@@ -7,8 +7,7 @@ import { SHOT_LAYERS } from '../../utils/ShotLayers'
 
 const materialFactory = () => new THREE.MeshToonMaterial({
   color: 0xffffff,
-  emissive: 0x0,
-  flatShading: false
+  emissive: 0x0
 })
 
 const Environment = React.memo(({ path, environment, grayscale }) => {
@@ -23,15 +22,18 @@ const Environment = React.memo(({ path, environment, grayscale }) => {
     if (!gltf) return []
     let children = []
     let sceneData = onlyOfTypes(gltf.scene, ['Scene', 'Mesh', 'Group'])
+
     sceneData.traverse(child => {
       if (child.isMesh) {
         let mesh = child.clone()
         let material = materialFactory() 
         if (mesh.material.map) {
           material.map = mesh.material.map
+          material.flatShading = mesh.material.flatShading
           material.map.needsUpdate = true
         }
         mesh.material = material
+       
         children.push( <primitive
           key={`${mesh.uuid}`}
           object={mesh}

--- a/src/js/shot-generator/helpers/GrayscaleFragmentShader.js
+++ b/src/js/shot-generator/helpers/GrayscaleFragmentShader.js
@@ -2,9 +2,9 @@
 
 export const fragmentShaderChunk = [
     "  #ifdef GRAYSCALE",
-    "   float gray = dot(gl_FragColor.rgb, vec3(0.2627, 0.678, 0.0593));",
+    "   float gray = dot(gl_FragColor.rgb, vec3(0.3126, 0.8152, 0.1722));",
     "   vec3 grayscale = vec3(gray);",
-    "	gl_FragColor = vec4(grayscale, gl_FragColor.a );",
+    "	gl_FragColor = vec4(grayscale, gl_FragColor.a);",
     "  #endif",
 ].join("\n")
 

--- a/src/js/xr/src/components/Environment.js
+++ b/src/js/xr/src/components/Environment.js
@@ -34,6 +34,7 @@ const Environment = React.memo(({ gltf, environment, grayscale }) => {
 
         if (child.material.map) {
           material.map = child.material.map
+          material.flatShading = child.material.flatShading
           material.map.needsUpdate = true
         }
 


### PR DESCRIPTION
## Bug description
The environment texture is black.
The grayscale needs to be brighter.

## Root cause
Overriding of material for the environment sets the flat shading to false by default. The flatshaded environments require that flat shading of material set to true.

## Solution description
Added copying of original material flat shading state to overriding material.
Increased grayscale brightness.