### PR TITLE
Storyboarder: tooltips don't change on language change

### DIFF
--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -93,7 +93,6 @@ ipcRenderer.on("languageChanged", (event, lng) => {
   i18n.off("languageChanged", changeLanguage)
   i18n.changeLanguage(lng, () => {
     i18n.on("languageChanged", changeLanguage)
-    console.log("Language changed to ", lng)
     updateHTMLText()
   })
 })

--- a/src/js/window/main-window.js
+++ b/src/js/window/main-window.js
@@ -93,6 +93,7 @@ ipcRenderer.on("languageChanged", (event, lng) => {
   i18n.off("languageChanged", changeLanguage)
   i18n.changeLanguage(lng, () => {
     i18n.on("languageChanged", changeLanguage)
+    console.log("Language changed to ", lng)
     updateHTMLText()
   })
 })
@@ -172,6 +173,7 @@ const updateHTMLText = () => {
     translateTooltip("#toolbar-pomodoro-rest", "main-window.toolbar.pomodoro.toolbar-pomodoro-rest")
     translateTooltip("#toolbar-pomodoro-running", "main-window.toolbar.pomodoro.toolbar-pomodoro-running")
     //#endregion
+    tooltips.update()
   //#endregion
   //#region board-information
   renderShotMetadata()

--- a/src/js/window/tooltips.js
+++ b/src/js/window/tooltips.js
@@ -103,8 +103,18 @@ const init = () => {
   }
 }
 
+const update = () => {
+  for(let i = 0; i < tooltips.length; i++) {
+    let tooltip = tooltips[i]
+    tooltip.destroy()
+  }
+  tooltips = [];
+  init()
+}
+
 module.exports = {
   init,
+  update,
   setupTooltipForElement,
   housekeeping,
   getPrefs,


### PR DESCRIPTION
## Bug description
Tooltips in storyboarder don't change the description on language change.

## Root cause
The tooltips initialized only once and stored, so the language change doesn't affect them.

## Solution description
The solution is to recreate the tooltips on language change.