### PR TITLE
https-server: extract resolvePublicPath from getResource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2290,6 +2290,59 @@
         }
       }
     },
+    "@babel/register": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.12.1.tgz",
+      "integrity": "sha512-XWcmseMIncOjoydKZnWvWi0/5CUCD+ZYKhRwgYlWOrA8fGZ/FjuLRpqtIhLOVD/fvR1b9DQHtZPn68VvhpYf+Q==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^2.0.0",
+        "lodash": "^4.17.19",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.16"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "@babel/runtime": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
@@ -13698,6 +13751,12 @@
       "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.10.tgz",
       "integrity": "sha512-6SVxo3Ic2Qc09z1rCJh3No7ubizPLszImsMQnZZWfzeOC6SYU4orN214++c3ikB8uaP/A6dwSlO88A3ohI5oNA=="
     },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
     "node-releases": {
       "version": "1.1.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.36.tgz",
@@ -15427,6 +15486,15 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
+      }
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
       }
     },
     "pixi-gl-core": {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "@babel/plugin-transform-runtime": "^7.7.6",
     "@babel/preset-env": "^7.7.6",
     "@babel/preset-react": "^7.7.4",
+    "@babel/register": "7.12.1",
     "@tweenjs/tween.js": "^18.5.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-add-module-exports": "^1.0.2",

--- a/src/js/services/server/sockets.js
+++ b/src/js/services/server/sockets.js
@@ -15,19 +15,47 @@ import P2P from '../../shared/network/p2p'
 
 import {loadFileToBlob} from '../../shared/network/peerUtils'
 
-// Map all the reosource paths to actual paths
-const pathMap = {
-  '/data/system': (staticPath, projectPath, userDataPath) => path.join(staticPath, 'data', 'shot-generator'),
-  '/data/user': (staticPath, projectPath, userDataPath) => path.join(projectPath, 'models'),
-  '/data/snd': (staticPath, projectPath, userDataPath) => path.join(staticPath, 'public', 'snd'),
-  '/data/presets/poses': (staticPath, projectPath, userDataPath) => path.join(userDataPath, 'presets', 'poses'),
-  '/data/presets/handPoses': (staticPath, projectPath, userDataPath) => path.join(userDataPath, 'presets', 'handPoses'),
-  '/boards/images': (staticPath, projectPath, userDataPath) => path.join(projectPath, 'images')
+export const getPublicDirectories = (staticPath, projectPath, userDataPath) =>
+  new Map(Object.entries({
+    // /data/system
+    // /data/system/attachables
+    // /data/system/dummies
+    // /data/system/dummies
+    // /data/system/emotions
+    // /data/system/icons
+    // /data/system/images
+    // /data/system/objects
+    // /data/system/volumes
+    // '/data/system/xr'
+    // '/data/system/xr/ui
+    // '/data/system/xr/snd
+    '/data/system': path.join(staticPath, 'data', 'shot-generator'),
+
+    '/data/user': path.join(projectPath, 'models'),
+    '/data/snd': path.join(staticPath, 'public', 'snd'),
+
+    // /data/presets
+    // /data/presets/poses
+    // /data/presets/handPoses
+    // /data/presets/emotions
+    // /data/presets/objects
+    '/data/presets': path.join(userDataPath, 'presets'),
+
+    '/boards/images': path.join(projectPath, 'images')
+  }))
+
+// via https://nodejs.org/en/knowledge/file-system/security/introduction/#preventing-directory-traversal
+export const resolvePublicPath = (publicDirectories, filepath) => {
+  let normalized = path.normalize(filepath)
+
+  for (let [src, dst] of publicDirectories) {
+    if (normalized.startsWith(src)) {
+      return path.join(dst, normalized.substring(src.length))
+    }
+  }
+
+  throw new Error(`Access Denied for ${filepath}`)
 }
-
-const pathMapKeys = Object.keys(pathMap)
-
-
 
 const IO = {current: null}
 
@@ -60,6 +88,8 @@ const onUserConnect = (emit, broadcast, id, store) => {
 
 // Connect to the lobby server and watch all the eventss
 export const serve = (store, service, staticPath, projectPath, userDataPath) => {
+  const publicDirectories = getPublicDirectories(staticPath, projectPath, userDataPath)
+
   return new Promise((resolve, reject) => {
     const peer = P2P() // Connect
     const {io, broadcast} = peer
@@ -163,19 +193,22 @@ export const serve = (store, service, staticPath, projectPath, userDataPath) => 
 
       // Send a resource
       emitter.on('getResource', async ({type, filePath}) => {
-        console.log(type, filePath)
-        const key = pathMapKeys.find((item) => filePath.indexOf(item) !== -1)
-        
-        // Load resource as blob
-        console.log('Getting resource: ', filePath)
-        const image = await loadFileToBlob(path.join(pathMap[key](staticPath, projectPath, userDataPath), path.relative(key, filePath)))
-        console.log('Sending resource: ', image)
+        console.log('getResource', 'type:', type, 'filePath:', filePath)
 
-        // Tell user that some resource will be loaded next
-        emit('willLoad', {path: filePath})
+        try {
+          // Load resource as blob
+          let publicPath = resolvePublicPath(publicDirectories, { type, filePath })
+          const image = await loadFileToBlob(publicPath)
 
-        // Send resource(might be sent as a lot of chunks)
-        emit('getResource', {type, filePath, data: image})
+          // Tell user that some resource will be loaded next
+          emit('willLoad', { path: filePath })
+
+          // Send resource (might be sent as a lot of chunks)
+          emit('getResource', { type, filePath, data: image })
+
+        } catch (err) {
+          console.error(err)
+        }
       })
       
     })

--- a/src/js/services/server/sockets.js
+++ b/src/js/services/server/sockets.js
@@ -199,7 +199,7 @@ export const serve = (store, service, staticPath, projectPath, userDataPath) => 
 
         try {
           // Load resource as blob
-          let publicPath = resolvePublicPath(publicDirectories, { type, filePath })
+          let publicPath = resolvePublicPath(publicDirectories, filePath)
           const image = await loadFileToBlob(publicPath)
 
           // Tell user that some resource will be loaded next

--- a/src/js/services/server/sockets.js
+++ b/src/js/services/server/sockets.js
@@ -15,27 +15,30 @@ import P2P from '../../shared/network/p2p'
 
 import {loadFileToBlob} from '../../shared/network/peerUtils'
 
-// TODO test user hair in XR
-// TODO test emotions in XR
 export const getPublicDirectories = (staticPath, projectPath, userDataPath) =>
   new Map(Object.entries({
+    // e.g.:
     // /data/system
     // /data/system/attachables
-    // /data/system/dummies
     // /data/system/dummies
     // /data/system/emotions
     // /data/system/icons
     // /data/system/images
     // /data/system/objects
     // /data/system/volumes
-    // '/data/system/xr'
-    // '/data/system/xr/ui
-    // '/data/system/xr/snd
+    // /data/system/xr
+    // /data/system/xr/ui
+    // /data/system/xr/snd
     '/data/system': path.join(staticPath, 'data', 'shot-generator'),
 
+    // e.g.:
+    // data/user
+    // data/user/attachables
     '/data/user': path.join(projectPath, 'models'),
+
     '/data/snd': path.join(staticPath, 'public', 'snd'),
 
+    // e.g.:
     // /data/presets
     // /data/presets/poses
     // /data/presets/handPoses

--- a/src/js/services/server/sockets.js
+++ b/src/js/services/server/sockets.js
@@ -15,6 +15,8 @@ import P2P from '../../shared/network/p2p'
 
 import {loadFileToBlob} from '../../shared/network/peerUtils'
 
+// TODO test user hair in XR
+// TODO test emotions in XR
 export const getPublicDirectories = (staticPath, projectPath, userDataPath) =>
   new Map(Object.entries({
     // /data/system
@@ -59,7 +61,7 @@ export const resolvePublicPath = (publicDirectories, filepath) => {
 
 const IO = {current: null}
 
-// Map ation to the server standard
+// Map action to the server standard
 const getRemoteAction = (action, meta = {}) => {
   return {
     ...action,

--- a/src/js/shared/network/peerUtils.js
+++ b/src/js/shared/network/peerUtils.js
@@ -4,9 +4,9 @@ import {promisify} from 'util'
 const readFile = promisify(fs.readFile)
 
 // Loads file content as ArrayBuffer for sending through peerjs
-export const loadFileToBlob = async (path) => {
+export const loadFileToBlob = async (filepath) => {
   try {
-    const contents = await readFile(path)
+    const contents = await readFile(filepath)
     return Uint8Array.from(contents).buffer
   } catch (err) {
     console.error(err)

--- a/test/xr/sockets.renderer.test.js
+++ b/test/xr/sockets.renderer.test.js
@@ -1,0 +1,35 @@
+// npx electron-mocha -r @babel/register --watch --renderer test/xr/sockets.renderer.test.js
+
+import path from 'path'
+import fs from 'fs'
+import assert from 'assert'
+
+import {
+  getPublicDirectories,
+  resolvePublicPath
+} from '../../src/js/services/server/sockets'
+
+const staticPath = 'STATIC_PATH'
+const projectPath = 'PROJECT_PATH'
+const userDataPath = 'USER_DATA_PATH'
+
+const publicDirectories = getPublicDirectories(staticPath, projectPath, userDataPath)
+
+describe('resolvePublicPath', () => {
+  it('allows serving files from permitted directories', () => {
+    assert.strictEqual(
+      resolvePublicPath(publicDirectories, '/data/system/xr/controller.glb'),
+      'STATIC_PATH/data/shot-generator/xr/controller.glb'
+    )
+  })
+  it('prevents serving files from any other directories', () => {
+    assert.throws(
+      () => resolvePublicPath(publicDirectories, '/data/sub-directory/file.glb')
+    )
+  })
+  it('prevents directory traversal attacks', () => {
+    assert.throws(
+      () => resolvePublicPath(publicDirectories, '/data/system/xr/../../file.glb')
+    )
+  })
+})

--- a/test/xr/sockets.renderer.test.js
+++ b/test/xr/sockets.renderer.test.js
@@ -1,7 +1,5 @@
 // npx electron-mocha -r @babel/register --watch --renderer test/xr/sockets.renderer.test.js
 
-import path from 'path'
-import fs from 'fs'
 import assert from 'assert'
 
 import {


### PR DESCRIPTION
Makes `resolvePublicPath` its own function that can be tested independently.
Simplifies the list of public directories as `getPublicDirectories`