### PR TITLE
Shot-generator image insertion

### DIFF
--- a/src/js/locales/en-US.json
+++ b/src/js/locales/en-US.json
@@ -532,7 +532,7 @@
       "image": {
         "tooltip": {
           "title": "Add Image",
-          "description": "Add an image. You can specify a custom image properties on the left. This is useful for reference images or posters or matte paintings in your scene."
+          "description": "Useful for reference images, posters, or matte paintings in your scene. Once added, use the Inspector (at left) to select an image file and set properties. Images can also be pasted from the clipboard."
         },
         "title": "Image"
       },

--- a/src/js/shared/actions/scene-object-creators.js
+++ b/src/js/shared/actions/scene-object-creators.js
@@ -157,7 +157,7 @@ const createVolume = (id, camera, room) => {
   })
 }
 
-const createImage = (id, camera, room) => {
+const createImage = (id, camera, room, imagePath = 'placeholder') => {
   let { x, y, z, rotation } = generatePositionAndRotation(camera, room)
   
   return createObject({
@@ -174,7 +174,7 @@ const createImage = (id, camera, room) => {
     visible: true,
     opacity: 1,
     visibleToCam: true,
-    imageAttachmentIds: ['placeholder']
+    imageAttachmentIds: [imagePath]
   })
 }
 

--- a/src/js/shot-generator/components/Toolbar/index.js
+++ b/src/js/shot-generator/components/Toolbar/index.js
@@ -122,7 +122,7 @@ const Toolbar = connect(
         let reader = new FileReader()
         reader.onload = function() {
           if(reader.readyState == 2) {
-            let buffer = new Buffer(reader.result)
+            let buffer = Buffer.from(reader.result)
             fs.writeFileSync(imagePath, buffer)
             initCamera()
             undoGroupStart()

--- a/src/js/shot-generator/components/Toolbar/index.js
+++ b/src/js/shot-generator/components/Toolbar/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import React, { useMemo, useRef, useEffect }  from 'react'
+import React, { useMemo, useRef, useEffect, useContext }  from 'react'
 import {
   // action creators
   selectObject,
@@ -17,6 +17,8 @@ import SceneObjectCreators from '../../../shared/actions/scene-object-creators'
 
 import Icon from '../Icon'
 import useTooltip from '../../../hooks/use-tooltip'
+import FilepathsContext from '../../contexts/filepaths'
+
 import { useTranslation } from 'react-i18next'
 import fs from 'fs-extra'
 import path from 'path'
@@ -32,8 +34,7 @@ const preventDefault = (fn, ...args) => e => {
 const Toolbar = connect(
     state => ({
       room: getWorld(state).room,
-      server: state.server,
-      storyboarderFilePath: state.meta.storyboarderFilePath
+      server: state.server
     }),
     {
       selectObject,
@@ -71,10 +72,10 @@ const Toolbar = connect(
     ipcRenderer,
     withState,
 
-    notifications,
-
-    storyboarderFilePath
+    notifications
   }) => {
+    const { getAssetPath } = useContext(FilepathsContext)
+
     let cameraState = null
     let camera = useRef(null)
     let { t } = useTranslation()
@@ -116,8 +117,8 @@ const Toolbar = connect(
         let blob = item.getAsFile()
 
         let imageId = THREE.Math.generateUUID()
-        let imageDst = path.join('models', 'images', `${imageId}-texture.png`)
-        let imagePath = path.join(path.dirname(storyboarderFilePath), imageDst)
+        let imageProjectPath = `models/images/${imageId}-texture.png`
+        let imagePath = getAssetPath('image', imageProjectPath)
         let reader = new FileReader()
         reader.onload = function() {
           if(reader.readyState == 2) {
@@ -125,7 +126,7 @@ const Toolbar = connect(
             fs.writeFileSync(imagePath, buffer)
             initCamera()
             undoGroupStart()
-            createImage(imageId, camera.current, room.visible && roomObject3d, imageDst)
+            createImage(imageId, camera.current, room.visible && roomObject3d, imageProjectPath)
             selectObject(imageId)
             undoGroupEnd()
           }

--- a/src/js/shot-generator/components/Toolbar/index.js
+++ b/src/js/shot-generator/components/Toolbar/index.js
@@ -123,6 +123,7 @@ const Toolbar = connect(
         reader.onload = function() {
           if(reader.readyState == 2) {
             let buffer = Buffer.from(reader.result)
+            fs.ensureDirSync(path.dirname(imagePath))
             fs.writeFileSync(imagePath, buffer)
             initCamera()
             undoGroupStart()

--- a/src/js/shot-generator/hooks/use-insert-image.js
+++ b/src/js/shot-generator/hooks/use-insert-image.js
@@ -36,7 +36,7 @@ const useInsertImage = (initializeImage) => {
           let blob = item.getAsFile()
   
           let imageId = THREE.Math.generateUUID()
-          let imageProjectPath =path.join('models', 'images', `${imageId}-texture.png}`)
+          let imageProjectPath = path.join('models', 'images', `${imageId}-texture.png`)
           let imagePath = getAssetPath('image', imageProjectPath)
           let reader = new FileReader()
           reader.onload = function() {

--- a/src/js/shot-generator/hooks/use-insert-image.js
+++ b/src/js/shot-generator/hooks/use-insert-image.js
@@ -1,0 +1,59 @@
+import fs from 'fs-extra'
+import path from 'path'
+import { useContext } from 'react'
+import FilepathsContext from '../contexts/filepaths'
+const useInsertImage = (initializeImage) => {
+    const { getAssetPath } = useContext(FilepathsContext)
+    const dragOver =  (e) => { 
+        e.preventDefault(); 
+        e.stopPropagation(); 
+    }
+  
+    const imageDrop = (e) => {
+        for (const f of e.dataTransfer.files) { 
+          let { name, ext } = path.parse( f.path)
+          let imageId = THREE.Math.generateUUID()
+          let imageProjectPath = path.join('models', 'images', name + ext)
+          let imagePath = getAssetPath('image', imageProjectPath)
+          fs.ensureDirSync(path.dirname(imagePath))
+          if(!fs.existsSync(imagePath))
+            fs.copyFileSync(f.path, imagePath)
+          initializeImage(imageId, imageProjectPath)
+        } 
+    } 
+  
+    const createImageFromClipboard = (pasteEvent) => {
+        if(pasteEvent.clipboardData == false) {
+          return
+        }
+        let items = pasteEvent.clipboardData.items
+        if(items == undefined) {
+          return 
+        }
+        for(let i = 0; i < items.length; i++) {
+          let item = items[i]
+          if(item.type.indexOf("image") == -1) continue
+          let blob = item.getAsFile()
+  
+          let imageId = THREE.Math.generateUUID()
+          let imageProjectPath =path.join('models', 'images', `${imageId}-texture.png}`)
+          let imagePath = getAssetPath('image', imageProjectPath)
+          let reader = new FileReader()
+          reader.onload = function() {
+            if(reader.readyState == 2) {
+              let buffer = Buffer.from(reader.result)
+              fs.ensureDirSync(path.dirname(imagePath))
+              fs.writeFileSync(imagePath, buffer)
+              initializeImage(imageId, imageProjectPath)
+            }
+          }
+          reader.readAsArrayBuffer(blob)
+        }
+  
+    }
+
+    return { dragOver, imageDrop, createImageFromClipboard }
+  
+}
+
+export { useInsertImage }

--- a/src/js/shot-generator/services/filepaths.js
+++ b/src/js/shot-generator/services/filepaths.js
@@ -7,7 +7,8 @@ function getSystemDirectoryFor (pathToShotGeneratorData) {
       'character': path.join(pathToShotGeneratorData, 'dummies', 'gltf'),
       'attachable': path.join(pathToShotGeneratorData, 'attachables'),
       'emotion': path.join(pathToShotGeneratorData, 'emotions'),
-      'xr': path.join(pathToShotGeneratorData, 'xr')
+      'xr': path.join(pathToShotGeneratorData, 'xr'),
+      'image': path.join(pathToShotGeneratorData, 'images')
     }[type]
   }
 }
@@ -19,7 +20,8 @@ function getProjectDirectory (base) {
       'character': path.join(base, 'models', 'characters'),
       'environment': path.join(base, 'models', 'environments'),
       'attachable': path.join(base, 'models', 'attachables'),
-      'emotion': path.join(base, 'models', 'emotions')
+      'emotion': path.join(base, 'models', 'emotions'),
+      'image': path.join(base, 'models', 'images')
     }[type]
   }
 }

--- a/test/shot-generator/services/filepaths.renderer.test.js
+++ b/test/shot-generator/services/filepaths.renderer.test.js
@@ -65,5 +65,17 @@ describe('filepaths', function () {
         'PROJECT_DIR/models/attachables'
       )
     })
+    it('can get system image file path', () => {
+      assert.strictEqual(
+        getAssetPath('image', `placeholder.png`),
+        'APP_DIR/data/shot-generator/images/placeholder.png'
+      )
+    })
+    it('can get user image file path', () => {
+      assert.strictEqual(
+        getAssetPath('image', `models/images/texture.png`),
+        'PROJECT_DIR/models/images/texture.png'
+      )
+    })
   })
 })


### PR DESCRIPTION
## Feature description
Ability to insert an image into shot-generator either thought clipboard or drag and drop file
 
## Solution description
Inserting an image from the clipboard creates the new image file with generated id. Inserting image by drag and drop copies image from path, a potential problem might occur in [image-drawing](https://github.com/wonderunit/storyboarder/pull/2011) branch when multiple images reference the same file 

## Task 
- [x] Insert image from clipboard
- [x] Drag and drop image

