### PR TITLE
Blocking on drag

### DIFF
--- a/src/js/services/server/sockets.js
+++ b/src/js/services/server/sockets.js
@@ -220,6 +220,14 @@ export const serve = (store, service, staticPath, projectPath, userDataPath) => 
   })
 }
 
+export const blockObject = (ids) => {
+  dispatchRemote(_blockObject(ids), {ignoreSG: true})
+}
+
+export const unblockObject = (ids) => {
+  dispatchRemote(_unblockObject(ids), {ignoreSG: true})
+}
+
 // Redux middleware
 export const SGMiddleware = store => next => action => {
   /**
@@ -231,6 +239,7 @@ export const SGMiddleware = store => next => action => {
   if (!IO.current || (RestrictedActions.indexOf(action.type) !== -1)) {
     // If we select something
     if (SelectActions.indexOf(action.type) !== -1) {
+      /*
       let selectionsBefore = getSelections(store.getState()) // Get selections before store update
 
       const result = next(action) // Update store
@@ -239,16 +248,20 @@ export const SGMiddleware = store => next => action => {
       /**
        * Next, we should compare to arrays to understand what objects are free to select and what objects are restricted to select
        */
+      /*
       console.log('Before/After', selectionsBefore, selectionsAfter)
       const selectionsToBlock = selectionsAfter.filter(item => selectionsBefore.indexOf(item) === -1) // Get objects block
       const selectionsToUnblock = selectionsBefore.filter(item => selectionsAfter.indexOf(item) === -1) // Get objects to unblock
       console.log('Block/Unblock', selectionsToBlock, selectionsToUnblock)
 
-      if (selectionsToUnblock.length) dispatchRemote(_unblockObject(selectionsToUnblock), {ignoreSG: true}) // Unblock deselected
-      if (selectionsToBlock.length) dispatchRemote(_blockObject(selectionsToBlock), {ignoreSG: true}) // Block selected
+      if (selectionsToUnblock.length) dispatchRemote(unblockObject(selectionsToUnblock), {ignoreSG: true}) // Unblock deselected
+      if (selectionsToBlock.length) dispatchRemote(blockObject(selectionsToBlock), {ignoreSG: true}) // Block selected
 
       // Return new state
       return result
+      */
+      
+      next(action)
     }
     
     // Return new state

--- a/src/js/shared/network/client.js
+++ b/src/js/shared/network/client.js
@@ -1,5 +1,5 @@
 import {RestrictedActions, remoteStore, setId, SelectActions} from "../reducers/remoteDevice"
-import {_blockObject, _unblockObject, getSelections} from "../reducers/shot-generator"
+import {blockObject as blockObjectAction, unblockObject as unblockObjectAction, getSelections} from "../reducers/shot-generator"
 import P2P from './p2p'
 import EventEmmiter from 'events'
 
@@ -92,8 +92,18 @@ export const connect = (URI = '') => {
         // Send objects to block
         client.on('askForBlock', () => {
           let meta = {ignore: [remoteStore.getState().id]}
-          dispatchRemote(_blockObject(getSelections(appStore.getState())), meta)
+          dispatchRemote(blockObjectAction(getSelections(appStore.getState())), meta)
         })
+      }
+
+      const blockObject = (ids) => {
+        let meta = {ignore: [remoteStore.getState().id]}
+        dispatchRemote(blockObjectAction(ids), meta)
+      }
+      
+      const unblockObject = (ids) => {
+        let meta = {ignore: [remoteStore.getState().id]}
+        dispatchRemote(unblockObjectAction(ids), meta)
       }
   
       // Get all the boards
@@ -202,6 +212,7 @@ export const connect = (URI = '') => {
         // Not send restricted actions
         if (RestrictedActions.indexOf(action.type) !== -1) {
   
+          /*
           // If we select something
           if (SelectActions.indexOf(action.type) !== -1) {
             let meta = {ignore: [remoteStore.getState().id]}
@@ -214,11 +225,12 @@ export const connect = (URI = '') => {
             const selectionsToBlock = selectionsAfter.filter(item => selectionsBefore.indexOf(item) === -1)
             const selectionsToUnblock = selectionsBefore.filter(item => selectionsAfter.indexOf(item) === -1)
 
-            if (selectionsToUnblock.length) dispatchRemote(_unblockObject(selectionsToUnblock), meta) // Unblock deselected
-            if (selectionsToBlock.length) dispatchRemote(_blockObject(selectionsToBlock), meta) // Block selected
+            if (selectionsToUnblock.length) dispatchRemote(unblockObject(selectionsToUnblock), meta) // Unblock deselected
+            if (selectionsToBlock.length) dispatchRemote(blockObject(selectionsToBlock), meta) // Block selected
 
             return result
           }
+          */
   
           /* Dispatch */
           return next(action)
@@ -274,7 +286,11 @@ export const connect = (URI = '') => {
         isSceneDirty,
 
         getResource,
-        connectRequest
+        connectRequest,
+
+
+        blockObject,
+        unblockObject
       })
     })
   })

--- a/src/js/shared/reducers/shot-generator.js
+++ b/src/js/shared/reducers/shot-generator.js
@@ -235,7 +235,7 @@ const updateObject = (draft, state, props, { models }) => {
     delete props["locked"]
   }
   
-  if (draft.locked) {
+  if (draft.locked || draft.blocked) {
     return
   }
 

--- a/src/js/shot-generator/components/Three/InteractionManager.js
+++ b/src/js/shot-generator/components/Three/InteractionManager.js
@@ -22,6 +22,7 @@ import {
     deselectAttachable,
     getSceneObjects,
 } from '../../../shared/reducers/shot-generator'
+import {blockObject, unblockObject} from '../../../services/server/sockets';
 import BonesHelper from '../../../xr/src/three/BonesHelper'
 import throttle from 'lodash.throttle'
 import CameraControlsComponent from './CameraControlsComponet'
@@ -277,6 +278,7 @@ const InteractionManager = connect(
                     selections[0] === target.userData.id
                   ) {
                     if (target.userData.locked || target.userData.blocked) {
+                      unblockObject(target.userData.id)
                       selectObject(null)
                       selectBone(null)
                       setLastDownId(null)
@@ -298,6 +300,7 @@ const InteractionManager = connect(
                     // select the bone
                     if (!isSelectedControlPoint && hits.length) {
                       selectObject(target.userData.id)
+                      blockObject(target.userData.id)
                       setLastDownId(null)
                       
                       selectBone(hits[0].bone.uuid)
@@ -312,6 +315,7 @@ const InteractionManager = connect(
                 selections.includes(target.userData.id)
               ) {
                 shouldDrag = true
+                blockObject(target.userData.id)
               }
             }
               selectBone(null)
@@ -354,6 +358,7 @@ const InteractionManager = connect(
         SGIkHelper.getInstance().deselectControlPoint(event)
         if (dragTarget && dragTarget.target) {
           endDrag(updateObjects)
+          unblockObject(dragTarget.target.userData.id)
           if(dragTarget.target.userData.type === "character") {
             let attachables = scene.__interaction.filter(object => object.userData.bindedId === dragTarget.target.userData.id)
             withState((dispatch, state) => {

--- a/src/js/shot-generator/helpers/outlineMaterial.js
+++ b/src/js/shot-generator/helpers/outlineMaterial.js
@@ -12,7 +12,7 @@ export const patchMaterial = (material, customParameters = {}) => {
   return material
 }
 
-export const setSelected = (object, selected = false, blocked = false, defaultColor = 0xcccccc,) => {
+export const setSelected = (object, selected = false, blocked = false, defaultColor = 0xcccccc) => {
   if (!object.material && !object.isMaterial) {
     return false
   }

--- a/src/js/xr/src/SceneManagerXR.js
+++ b/src/js/xr/src/SceneManagerXR.js
@@ -557,7 +557,8 @@ const SceneContent = connect(
       uiService,
       playSound,
       stopSound,
-      realCamera
+      realCamera,
+      SGConnection
     })
     
     useFrame(({camera, gl}) => {

--- a/src/js/xr/src/use-interactions-manager.js
+++ b/src/js/xr/src/use-interactions-manager.js
@@ -1389,7 +1389,7 @@ const useInteractionsManager = ({
             
             controller.attach(object)
             object.updateMatrixWorld(true)
-            dispatch(SGConnection.blockObject(context.selection))
+            SGConnection.blockObject(context.selection)
           }
 
           playSound('beam', object)
@@ -1433,7 +1433,7 @@ const useInteractionsManager = ({
             }
           }
 
-          dispatch(SGConnection.unblockObject(context.selection))
+          SGConnection.unblockObject(context.selection)
 
           uiService.send({ type: 'UNLOCK' })
         },

--- a/src/js/xr/src/use-interactions-manager.js
+++ b/src/js/xr/src/use-interactions-manager.js
@@ -309,7 +309,8 @@ const useInteractionsManager = ({
   uiService,
   playSound,
   stopSound,
-  realCamera
+  realCamera,
+  SGConnection
 }) => {
   const { gl, camera, scene } = useThree()
 
@@ -1388,6 +1389,7 @@ const useInteractionsManager = ({
             
             controller.attach(object)
             object.updateMatrixWorld(true)
+            dispatch(SGConnection.blockObject(context.selection))
           }
 
           playSound('beam', object)
@@ -1430,6 +1432,8 @@ const useInteractionsManager = ({
               commit(mapAttachables[i].userData.id, mapAttachables[i])
             }
           }
+
+          dispatch(SGConnection.unblockObject(context.selection))
 
           uiService.send({ type: 'UNLOCK' })
         },


### PR DESCRIPTION
The idea was to block an object only when the user drags it, not on select.
Blocking dragging object prevents a bug situation when a few users try to drag it at the same time.